### PR TITLE
Minor bug fixes and improvement suggestions

### DIFF
--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -217,7 +217,7 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
 
       return { hash: tx.txid, fee: BigInt(tx.fee) }
     } catch (e) {
-      throw new Error(`Failed to send transaction to ${to}: ${e.message}`)
+      throw new Error(`Failed to send transaction to ${to}: ${e}`)
     }
   }
 
@@ -372,7 +372,7 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
 
         return hex
       } catch (e) {
-        throw new Error(`Failed to get transaction hex: ${e.message}`)
+        throw new Error(`Failed to get transaction hex: ${e}`)
       }
     }
 

--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -241,6 +241,7 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
    * @returns {Promise<BtcTransfer[]>} The bitcoin transfers.
    */
   async getTransfers (options = {}) {
+    // this function can be implemented in WalletAccountReadOnlyBtc, this way we can also expands the use case for read-only account
     // i believe we refactor this function to improve performance and readability,
     // there are too many nested for loops and async calls within loops
     // also, the function is pretty complex, splitting it up into smaller private functions would be an improvement

--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -199,22 +199,26 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
   async sendTransaction ({ to, value }) {
     const address = await this.getAddress()
 
-    const feeEstimate = await this._electrumClient.blockchainEstimatefee(1)
+    try {
+      const feeEstimate = await this._electrumClient.blockchainEstimatefee(1)
 
-    const feeRate = Math.max(Number(feeEstimate) * 100_000, 1)
+      const feeRate = Math.max(Number(feeEstimate) * 100_000, 1)
 
-    const { utxos, fee, changeValue } = await this._planSpend({
-      fromAddress: address,
-      toAddress: to,
-      amount: value,
-      feeRate
-    })
+      const { utxos, fee, changeValue } = await this._planSpend({
+        fromAddress: address,
+        toAddress: to,
+        amount: value,
+        feeRate
+      })
 
-    const tx = await this._getRawTransaction({ utxos, to, value, fee, feeRate, changeValue })
+      const tx = await this._getRawTransaction({ utxos, to, value, fee, feeRate, changeValue })
 
-    await this._electrumClient.blockchainTransaction_broadcast(tx.hex)
+      await this._electrumClient.blockchainTransaction_broadcast(tx.hex)
 
-    return { hash: tx.txid, fee: BigInt(tx.fee) }
+      return { hash: tx.txid, fee: BigInt(tx.fee) }
+    } catch (e) {
+      throw new Error(`Failed to send transaction to ${to}: ${e.message}`)
+    }
   }
 
   /**
@@ -237,6 +241,9 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
    * @returns {Promise<BtcTransfer[]>} The bitcoin transfers.
    */
   async getTransfers (options = {}) {
+    // i believe we refactor this function to improve performance and readability,
+    // there are too many nested for loops and async calls within loops
+    // also, the function is pretty complex, splitting it up into smaller private functions would be an improvement
     const { direction = 'all', limit = 10, skip = 0 } = options
 
     const net = this._network
@@ -357,9 +364,15 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
     const legacyPrevTxCache = new Map()
     const getPrevTxHex = async (txid) => {
       if (legacyPrevTxCache.has(txid)) return legacyPrevTxCache.get(txid)
-      const hex = await this._electrumClient.blockchainTransaction_get(txid, false)
-      legacyPrevTxCache.set(txid, hex)
-      return hex
+
+      try {
+        const hex = await this._electrumClient.blockchainTransaction_get(txid, false)
+        legacyPrevTxCache.set(txid, hex)
+
+        return hex
+      } catch (e) {
+        throw new Error(`Failed to get transaction hex: ${e.message}`)
+      }
     }
 
     const buildAndSign = async (rcptVal, chgVal) => {

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -107,7 +107,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 
       return BigInt(confirmed)
     } catch (e) {
-      throw new Error(`Failed to fetch balance from Electrum: ${e.message}`)
+      throw new Error(`Failed to fetch balance from Electrum: ${e}`)
     }
   }
 
@@ -135,7 +135,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     try {
       feeRate = await this._electrumClient.blockchainEstimatefee(1)
     } catch (e) {
-      throw new Error(`Failed to estimate fee with Electrum: ${e.message}`)
+      throw new Error(`Failed to estimate fee with Electrum: ${e}`)
     }
 
     const { fee } = await this._planSpend({
@@ -185,7 +185,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 
       return transaction
     } catch (e) {
-      throw new Error(`Failed to get transaction receipt for hash ${hash}: ${e.message}`)
+      throw new Error(`Failed to get transaction receipt for hash ${hash}: ${e}`)
     }
   }
 
@@ -242,7 +242,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     try {
       unspent = await this._electrumClient.blockchainScripthash_listunspent(scriptHash)
     } catch (e) {
-      throw new Error(`Failed to fetch UTXO list from Electrum: ${e.message}`)
+      throw new Error(`Failed to fetch UTXO list from Electrum: ${e}`)
     }
 
     if (!unspent || unspent.length === 0) {

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -189,6 +189,10 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     }
   }
 
+  dispose () {
+    this._electrumClient.close()
+  }
+
   /**
    * Computes the sha-256 hash of the output script for this wallet's address, reverses the byte order,
    * and returns it as a hex string.

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -102,9 +102,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
   async getBalance () {
     const scriptHash = await this._getScriptHash()
 
-    const { confirmed } = await this._electrumClient.blockchainScripthash_getBalance(scriptHash)
+    try {
+      const { confirmed } = await this._electrumClient.blockchainScripthash_getBalance(scriptHash)
 
-    return BigInt(confirmed)
+      return BigInt(confirmed)
+    } catch (e) {
+      throw new Error(`Failed to fetch balance from Electrum: ${e.message}`)
+    }
   }
 
   /**
@@ -126,7 +130,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
   async quoteSendTransaction ({ to, value }) {
     const address = await this.getAddress()
 
-    const feeRate = await this._electrumClient.blockchainEstimatefee(1)
+    let feeRate
+
+    try {
+      feeRate = await this._electrumClient.blockchainEstimatefee(1)
+    } catch (e) {
+      throw new Error(`Failed to estimate fee with Electrum: ${e.message}`)
+    }
 
     const { fee } = await this._planSpend({
       fromAddress: address,
@@ -160,18 +170,23 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     }
 
     const scriptHash = await this._getScriptHash()
-    const history = await this._electrumClient.blockchainScripthash_getHistory(scriptHash)
-    const item = Array.isArray(history) ? history.find(h => h?.tx_hash === hash) : null
 
-    if (!item || !item.height || item.height <= 0) {
-      return null
+    try {
+      const history = await this._electrumClient.blockchainScripthash_getHistory(scriptHash)
+      const item = Array.isArray(history) ? history.find(h => h?.tx_hash === hash) : null
+
+      if (!item || !item.height || item.height <= 0) {
+        return null
+      }
+
+      const hex = await this._electrumClient.blockchainTransaction_get(hash, false)
+
+      const transaction = Transaction.fromHex(hex)
+
+      return transaction
+    } catch (e) {
+      throw new Error(`Failed to get transaction receipt for hash ${hash}: ${e.message}`)
     }
-
-    const hex = await this._electrumClient.blockchainTransaction_get(hash, false)
-
-    const transaction = Transaction.fromHex(hex)
-
-    return transaction
   }
 
   /**
@@ -218,7 +233,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 
     const scriptHash = await this._getScriptHash()
 
-    const unspent = await this._electrumClient.blockchainScripthash_listunspent(scriptHash)
+    let unspent
+
+    try {
+      unspent = await this._electrumClient.blockchainScripthash_listunspent(scriptHash)
+    } catch (e) {
+      throw new Error(`Failed to fetch UTXO list from Electrum: ${e.message}`)
+    }
 
     if (!unspent || unspent.length === 0) {
       throw new Error('No unspent outputs available.')

--- a/src/wallet-manager-btc.js
+++ b/src/wallet-manager-btc.js
@@ -72,6 +72,8 @@ export default class WalletManagerBtc extends WalletManager {
    * @returns {Promise<FeeRates>} The fee rates (in satoshis).
    */
   async getFeeRates () {
+    // this function does not handle mainnet/testnet config
+    // also, we should allow user to pass in API key for mempool APIs
     const response = await fetch(`${MEMPOOL_SPACE_URL}/api/v1/fees/recommended`)
 
     const { fastestFee, hourFee } = await response.json()


### PR DESCRIPTION
# Description
After testing the module in node/bare enviroment, i discovered a few things:

1. we should have `dispose` method for btc readonly account, program doesn't exit properly unless we close the electrum connection

```
🧪 Testing getBalance() method...
✅ Balance retrieved successfully
   Balance: 11362404 satoshis (0 BTC)

🎉 Test completed!



================================================
================================================
🏁 Ended @wdk/wallet-btc package tests
================================================
================================================
Keep-Alive ping failed: 
Keep-Alive ping failed: 
```

2. Error unhandled in electrum API calls

i tested `quoteSendTransaction` and encountered this problem: upon calling `blockchainScripthash_listunspent` with electrum client, it was an unhandled promise rejection which led to `_planSpend` return undefined with no error properly thrown. adding try catch block solved this, now it throws error `Too many history entries`. given this behavior, i added try catch block to electrum client calls to correctly throws unexpected errors

i tested `quoteSendTransaction` with this address on testnet: `mxV3NFWUGQHRGUyiDb82WACW62BS39Ddbn`

```
🧪 Testing quoteSendTransaction() method...
⚠️  quoteSendTransaction test failed: undefined

🎉 Test completed!
```

3. `getFeeRates` in `WalletManagerBtc` does not handle mainnet/testnet. it always calls mainnet api. Also we should have config to allow user to pass in API key

4. `getTransfers` can be implemented in readOnly account. can we give this function a thorough review? it's using a lot of nested for loops and api calls within for loop, this is critical when user address has a lot of utxos. i tested with such an account and the program just froze, i think we need to refactor to reduce nested loops and utilize `Promise.all`

5. I'm getting this error when trying to send a transaction

```

🧪 Testing sendTransaction() method...
⚠️  sendTransaction test failed: Failed to send transaction to tb1qx3fju0uclmp0xmqzhxjcydeal6eky95srd2laj: cannot estimate fee for 1 blocks

```