### PR TITLE
Bound concurrency & cache for getTransfers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,8 +18,8 @@
         "bip32": "4.0.0",
         "bip39": "3.1.0",
         "bitcoinjs-lib": "6.1.7",
-        "lru-cache": "^11.2.2",
-        "p-limit": "^7.1.1",
+        "lru-cache": "11.2.2",
+        "p-limit": "7.1.1",
         "sodium-universal": "5.0.1"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "bip32": "4.0.0",
     "bip39": "3.1.0",
     "bitcoinjs-lib": "6.1.7",
-    "lru-cache": "^11.2.2",
-    "p-limit": "^7.1.1",
+    "lru-cache": "11.2.2",
+    "p-limit": "7.1.1",
     "sodium-universal": "5.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description
Refactors `getTransfers` to be concurrency-aware and more resilient when querying transactions:

- Introduces bounded concurrency using `p-limit` (`CONCURRENCY_LIMIT`) to throttle `blockchainTransaction_get` calls.
- Adds `LRUCache` for transactions and previous UTXOs.
- Batches history processing (`BATCH_SIZE`) to limit in-flight work and memory pressure.

Smaller improvements include:
- Extracts `getPrevUtxo` with caching and a fast-path for coinbase inputs.
- Computes direction and fees in a clearer, two-phase pass (outputs, then inputs).

## Motivation and Context
See #34, point 4. We used a cache for UTXOs. Note that to classify a tx as incoming or outgoing and compute fees, we need its input UTXOs. In a big wallet, say 10k txs, assuming 5KB memory space per tx cache, we'd be using 100MB+ memory. In most modern phones that will freeze or feel uncomfortable. Also, unbounded concurrent calls can cause instability.

The new version:
- Caps concurrent RPCs for stability,
- Implements LRU caches,
- Processes history in controllable batches,
- Improves overall user-perceived responsiveness for large addresses.

## Related Issue
See #34. 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update