### PR TITLE
Infer dust limit from wallet type

### DIFF
--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -24,7 +24,7 @@ import * as ecc from '@bitcoinerlab/secp256k1'
 // eslint-disable-next-line camelcase
 import { sodium_memzero } from 'sodium-universal'
 
-import WalletAccountReadOnlyBtc, { DUST_LIMIT } from './wallet-account-read-only-btc.js'
+import WalletAccountReadOnlyBtc from './wallet-account-read-only-btc.js'
 
 /** @typedef {import('@tetherto/wdk-wallet').IWalletAccount} IWalletAccount */
 
@@ -422,12 +422,12 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
 
     if (currentChange > 0) {
       const newChange = currentChange - delta
-      currentChange = newChange > DUST_LIMIT ? newChange : 0
+      currentChange = newChange > this._dustLimit ? newChange : 0
       tx = await buildAndSign(currentRecipientAmnt, currentChange)
     } else {
       const newRecipientAmnt = currentRecipientAmnt - delta
-      if (newRecipientAmnt <= DUST_LIMIT) {
-        throw new Error(`The amount after fees must be bigger than the dust limit (= ${DUST_LIMIT}).`)
+      if (newRecipientAmnt <= this._dustLimit) {
+        throw new Error(`The amount after fees must be bigger than the dust limit (= ${this._dustLimit}).`)
       }
       currentRecipientAmnt = newRecipientAmnt
       tx = await buildAndSign(currentRecipientAmnt, currentChange)

--- a/tests/wallet-account-btc.test.js
+++ b/tests/wallet-account-btc.test.js
@@ -7,7 +7,6 @@ import { HOST, PORT, ELECTRUM_PORT, ZMQ_PORT, DATA_DIR } from './config.js'
 import { BitcoinCli, Waiter } from './helpers/index.js'
 
 import { WalletAccountBtc, WalletAccountReadOnlyBtc } from '../index.js'
-import { DUST_LIMIT } from '../src/wallet-account-read-only-btc.js'
 
 const SEED_PHRASE = 'cook voyage document eight skate token alien guide drink uncle term abuse'
 
@@ -217,7 +216,8 @@ describe.each([44, 84])(`WalletAccountBtc`, (bip) => {
       const nearMaxAmount = Math.max(1, Number(balance) - 2_000)
       const { fee: feeEstimate } = await account.quoteSendTransaction({ to: recipient, value: nearMaxAmount })
 
-      const spend = Math.max(1, Number(balance) - Number(feeEstimate) - (DUST_LIMIT - 1))
+      const dustLimit = account._dustLimit
+      const spend = Math.max(1, Number(balance) - Number(feeEstimate) - (dustLimit - 1))
       const { hash, fee } = await account.sendTransaction({ to: recipient, value: spend })
       await waiter.mine()
 
@@ -235,7 +235,8 @@ describe.each([44, 84])(`WalletAccountBtc`, (bip) => {
     })
 
     test('should throw if value is less than the dust limit', async () => {
-      await expect(account.sendTransaction({ to: recipient, value: 500 }))
+      const value = Math.floor(account._dustLimit / 2)
+      await expect(account.sendTransaction({ to: recipient, value }))
         .rejects.toThrow('The amount must be bigger than the dust limit')
     })
 

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -71,7 +71,6 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
   describe('getMaxSpendable', () => {
     const TX_OVERHEAD_VBYTES = 11
     const OUTPUT_VBYTES = 34
-    const DUST_LIMIT = 546
     const MIN_TX_FEE = 141
     const STARTING_BALANCE = 1_000_000n
     const INPUT_VBYTES = bip === 44 ? 148 : 68
@@ -81,23 +80,26 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
 
       const vsize = TX_OVERHEAD_VBYTES + INPUT_VBYTES + (2 * OUTPUT_VBYTES)
       const expectedFee = BigInt(Math.max(Math.ceil(vsize * satsPerVByte), MIN_TX_FEE))
-      const expectedAmount = STARTING_BALANCE - expectedFee - BigInt(DUST_LIMIT)
+      const dustLimit = account._dustLimit
+      const expectedAmount = STARTING_BALANCE - expectedFee - BigInt(dustLimit)
 
       const result = await account.getMaxSpendable()
 
       expect(result).toEqual({
         amount: expectedAmount,
         fee: expectedFee,
-        changeValue: BigInt(DUST_LIMIT)
+        changeValue: BigInt(dustLimit)
       })
     })
 
     test('should return correct max spend when change would be dust (one output)', async () => {
       const satsPerVByte = bitcoin.estimateSatsPerVByte(1)
 
-      const freshAddress = bip === 44
+      const tmpAddress = bip === 44
         ? bitcoin.call('getnewaddress "" legacy', { rawResult: true })
         : bitcoin.call('getnewaddress "" bech32', { rawResult: true })
+      const tmpAccount = new WalletAccountReadOnlyBtc(tmpAddress, CONFIGURATION)
+      const dustLimit = tmpAccount._dustLimit
 
       const vsizeOneOutput = TX_OVERHEAD_VBYTES + INPUT_VBYTES + OUTPUT_VBYTES
       const feeOneOutput = Math.max(Math.ceil(vsizeOneOutput * satsPerVByte), MIN_TX_FEE)
@@ -105,17 +107,16 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
       const vsizeTwoOutputs = TX_OVERHEAD_VBYTES + INPUT_VBYTES + (2 * OUTPUT_VBYTES)
       const feeTwoOutputs = Math.max(Math.ceil(vsizeTwoOutputs * satsPerVByte), MIN_TX_FEE)
 
-      const minSpendable = feeOneOutput + DUST_LIMIT + 1
-      const maxSpendable = feeTwoOutputs + 2 * DUST_LIMIT
+      const minSpendable = feeOneOutput + dustLimit + 1
+      const maxSpendable = feeTwoOutputs + 2 * dustLimit
 
       const oneOutputRange = Math.max(1, maxSpendable - minSpendable)
 
       const fundedAmount = minSpendable + Math.min(1000, oneOutputRange - 1)
 
-      bitcoin.sendToAddress(freshAddress, (fundedAmount / 1e8).toFixed(8))
+      bitcoin.sendToAddress(tmpAddress, (fundedAmount / 1e8).toFixed(8))
       await waiter.mine()
 
-      const tmpAccount = new WalletAccountReadOnlyBtc(freshAddress, CONFIGURATION)
       const result = await tmpAccount.getMaxSpendable()
 
       expect(result).toEqual({


### PR DESCRIPTION
# Description
We now set the dust limit dynamically based on the address type (BIP-44 or BIP-84).

# Motivation and Context

The dust limit was hardcoded to `546` sats, the default for legacy BIP-44 addresses. This value is incorrect when working with other wallet types.

For future reference, you can find dust limits for other address types here: https://help.magiceden.io/en/articles/9567686-understanding-bitcoin-wallet-types-and-dust-limits-on-magic-eden

# Type of change

- [x] Bug fix (non-breaking change which fixes an issue)  
- [ ] New feature (non-breaking change which adds functionality)  
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)  
- [ ] This change requires a documentation update