### PR TITLE
Add support for custom feeRate and confirmationTarget

### DIFF
--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -196,12 +196,13 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
    * @param {BtcTransaction} tx - The transaction.
    * @returns {Promise<TransactionResult>} The transaction's result.
    */
-  async sendTransaction ({ to, value }) {
+  async sendTransaction ({ to, value, confirmationTarget = 1, feeRate = undefined }) {
     const address = await this.getAddress()
 
-    const feeEstimate = await this._electrumClient.blockchainEstimatefee(1)
-
-    const feeRate = Math.max(Number(feeEstimate) * 100_000, 1)
+    if (typeof feeRate !== 'number') {
+      const feeEstimate = await this._electrumClient.blockchainEstimatefee(confirmationTarget)
+      feeRate = Math.max(Number(feeEstimate) * 100_000, 1)
+    }
 
     const { utxos, fee, changeValue } = await this._planSpend({
       fromAddress: address,

--- a/tests/wallet-account-btc.test.js
+++ b/tests/wallet-account-btc.test.js
@@ -183,6 +183,25 @@ describe.each([44, 84])(`WalletAccountBtc`, (bip) => {
       expect(fee).toBe(BigInt(feeSats))
     })
 
+    test('should successfully send a transaction with a fixed fee rate', async () => {
+      const FIXED_FEE_RATE = 10 
+      const TRANSACTION = { to: recipient, value: 1_000, feeRate: FIXED_FEE_RATE }
+
+      const { hash, fee } = await account.sendTransaction(TRANSACTION)
+
+      await waiter.mine()
+
+      const transaction = bitcoin.getTransaction(hash)
+      expect(transaction.txid).toBe(hash)
+      expect(transaction.details[0].address).toBe(TRANSACTION.to)
+
+      const amount = Math.round(transaction.details[0].amount * 1e8)
+      expect(amount).toBe(TRANSACTION.value)
+
+      const feeSats = bitcoin.getTransactionFeeSats(hash)
+      expect(fee).toBe(BigInt(feeSats))
+    })
+
     test('should create a change output when leftover > dust limit', async () => {
       const TRANSACTION = { to: recipient, value: 500_000 }
 

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -138,6 +138,16 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
       const expectedFee = FEES[bip] * BigInt(satsPerVByte)
       expect(fee).toBe(expectedFee)
     })
+    
+    test('should successfully quote a transaction with a fixed fee rate', async () => {
+      const FIXED_FEE_RATE = 12
+      const TRANSACTION = { to: recipient, value: 1_000, feeRate: FIXED_FEE_RATE }
+
+      const { fee } = await account.quoteSendTransaction(TRANSACTION)
+      
+      const expectedFee = FEES[bip] * BigInt(FIXED_FEE_RATE)
+      expect(fee).toBe(expectedFee)
+    })
   })
 
   describe('quoteTransfer', () => {


### PR DESCRIPTION
# Description

Adds support for customizing transaction fee calculation by introducing optional `feeRate` and `confirmationTarget` parameters to `quoteSendTransaction` & `sendTransaction`. If a `feeRate` is provided, it overrides dynamic fee estimation from the Electrum server. If not, the `confirmationTarget` is used to determine the urgency of confirmation.

---

## Motivation and Context

Previously, we used Electrum's estimated fee for confirmation within 1 block. The update enables more control and adaptability by allowing:
- Explicit fee rate overrides (in sat/vB)
- Custom confirmation targets (e.g. 3 blocks for medium priority)

---

## Type of change

- [x] New feature (non-breaking change which adds functionality)