### PR TITLE
Fix Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/general.md
+++ b/.github/ISSUE_TEMPLATE/general.md
@@ -1,3 +1,11 @@
+---
+name: "General issue"
+about: "Use this for bugs, features, or docs changes"
+title: ""
+labels: []
+assignees: []
+---
+
 ## I'm submitting a...
 
 - [ ] bug report
@@ -5,12 +13,15 @@
 - [ ] documentation change
 
 ## What is the expected behaviour?
+
 <!--- Describe the expected behaviour in details. -->
 
 ## What is the current behaviour?
+
 <!--- Describe the current behaviour in details. -->
 
 ## Possible solution (optional)
+
 <!-- If you have a solution proposal, please explain it here. -->
 <!-- If your solution includes implementation, you should also open a pull request with this as related issue. -->
 <!-- You can delete this section if you don't want to suggest a possible solution. -->
@@ -18,13 +29,16 @@
 A possible solution could be...
 
 ## Steps to reproduce (for bugs)
+
 <!-- You can delete this section if you are not submitting a bug report. -->
 
-1. 
-2. 
-3. 
+1.
+2.
+3.
 
 ### Node version
+
 <!-- Indicate your node version here. -->
 <!-- You can print it using `node --version`. -->
+
 Node v22.13.1 x64


### PR DESCRIPTION
# Description
Add single foldered issue template: `.github/ISSUE_TEMPLATE/general.md`.

## Motivation and Context
Legacy `.github/ISSUE_TEMPLATE.md` wasn’t loading in the New Issue UI. This enforces a default template.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
