### PR TITLE
fix: re-use read only class

### DIFF
--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -400,12 +400,14 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
    * @returns {Promise<WalletAccountReadOnlyBtc>} The read-only account.
    */
   async toReadOnlyAccount () {
-    const btcReadOnlyAccount = new WalletAccountReadOnlyBtc(this._address, {
-      ...this._config,
-      client: this._client
-    })
+    if (!this._btcReadOnlyAccount) {
+      this._btcReadOnlyAccount = new WalletAccountReadOnlyBtc(this._address, {
+        ...this._config,
+        client: this._client
+      })
+    }
 
-    return btcReadOnlyAccount
+    return this._btcReadOnlyAccount
   }
 
   /**


### PR DESCRIPTION
- if an instance of the read only class already exists, don't create a new one