### PR TITLE
Release: v1.0.0-beta.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 env:
   ELECTRS_VERSION_TAG: "0.10.10"
   BITCOIND_VERSION_TAG: "29.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet-btc",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet-btc",
-      "version": "1.0.0-beta.8",
+      "version": "1.0.0-beta.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/coinselect": "1.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@bitcoinerlab/secp256k1": "1.2.0",
         "@mempool/electrum-client": "1.1.9",
         "@tetherto/wdk-failover-provider": "1.0.0-beta.2",
-        "@tetherto/wdk-wallet": "1.0.0-beta.7",
+        "@tetherto/wdk-wallet": "1.0.0-beta.8",
         "bare-node-runtime": "^1.1.4",
         "bip32": "4.0.0",
         "bip39": "3.1.0",
@@ -1202,9 +1202,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@tetherto/wdk-wallet": {
-      "version": "1.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.7.tgz",
-      "integrity": "sha512-QJJPhA+adCImQ/nMymmMeW4x0Ey65vEgWfoDjuXtdaD7LnFdCChFvZXcyDQUH3ghSTnve6MDutMmvfDIxhipVg==",
+      "version": "1.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.8.tgz",
+      "integrity": "sha512-eCOpPbgRrwVuB7mJS1zGVVN47n/pvX5gLRG+WERH0NmpcIS8OHxa4DYuTJ9P1qEZYRvYl4XOSrhfizC/foonDQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.1.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2753,9 +2753,9 @@
       "license": "MIT"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet-btc",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.9",
   "description": "A simple package to manage BIP-32 wallets for the bitcoin blockchain.",
   "keywords": [
     "wdk",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@mempool/electrum-client": "1.1.9",
     "@tetherto/wdk-failover-provider": "1.0.0-beta.2",
-    "@tetherto/wdk-wallet": "1.0.0-beta.7",
+    "@tetherto/wdk-wallet": "1.0.0-beta.8",
     "bare-node-runtime": "^1.1.4",
     "bip32": "4.0.0",
     "bip39": "3.1.0",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.9

### Changes since v1.0.0-beta.8
- Feature: Sign transaction support (#88)
- Feature: Failover provider support (#76)
- Fix: Re-use read only class (#89)
- Fix: Key pair property (#81)
- Fix: CI pipeline (#83)

Made with [Cursor](https://cursor.com)