### PR TITLE
feat: add optional OP_RETURN memo to sendTransaction / signTransaction

### DIFF
--- a/src/wallet-account-btc.js
+++ b/src/wallet-account-btc.js
@@ -72,9 +72,36 @@ const REQUEST_BATCH_SIZE = 64
 
 const POLLING_INTERVAL = 300
 
+// Bitcoin Core standardness limit for OP_RETURN payloads on relay
+// (MAX_OP_RETURN_RELAY in policy.h). Transactions with larger payloads
+// are valid by consensus but won't propagate on the default mempool.
+export const MAX_OP_RETURN_BYTES = 80
+
 const bip32 = BIP32Factory(ecc)
 
 initEccLib(ecc)
+
+/**
+ * Normalizes a memo payload into a Buffer of raw bytes for embedding in
+ * an OP_RETURN output, or `null` when no memo is supplied.
+ *
+ * @param {string | Uint8Array | Buffer | null | undefined} memo - The memo bytes.
+ * @returns {Buffer | null} The memo as a Buffer, or null when omitted.
+ * @throws {RangeError} When the memo exceeds the OP_RETURN standardness cap.
+ */
+export function _normalizeMemo (memo) {
+  if (memo === undefined || memo === null) return null
+  const buf = typeof memo === 'string'
+    ? Buffer.from(memo, 'utf8')
+    : Buffer.from(memo)
+  if (buf.length === 0) return null
+  if (buf.length > MAX_OP_RETURN_BYTES) {
+    throw new RangeError(
+      `OP_RETURN memo is ${buf.length} bytes; the standardness rule caps it at ${MAX_OP_RETURN_BYTES} bytes.`
+    )
+  }
+  return buf
+}
 
 function derivePath (seed, path) {
   const masterKeyAndChainCodeBuffer = hmac(sha512, MASTER_SECRET, seed)
@@ -206,8 +233,8 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
    * @returns {Promise<string>} The signed raw transaction as a hex string.
    * @throws {Error} If the transaction's cost exceeds the maximum transaction fee option.
    */
-  async signTransaction ({ to, value, feeRate, confirmationTarget = 1 }) {
-    const { tx } = await this._buildSignedTransaction({ to, value, feeRate, confirmationTarget })
+  async signTransaction ({ to, value, feeRate, confirmationTarget = 1, memo }) {
+    const { tx } = await this._buildSignedTransaction({ to, value, feeRate, confirmationTarget, memo })
 
     if (this._config.transactionMaxFee !== undefined && tx.fee > this._config.transactionMaxFee) {
       throw new Error('Exceeded maximum fee cost for transaction operation.')
@@ -224,8 +251,8 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
    * @returns {Promise<TransactionResult>} The transaction's result.
    * @throws {Error} If the transaction's cost exceeds the maximum transaction fee option.
    */
-  async sendTransaction ({ to, value, feeRate, confirmationTarget = 1 }, timeoutMs = 10000) {
-    const { tx, utxos } = await this._buildSignedTransaction({ to, value, feeRate, confirmationTarget })
+  async sendTransaction ({ to, value, feeRate, confirmationTarget = 1, memo }, timeoutMs = 10000) {
+    const { tx, utxos } = await this._buildSignedTransaction({ to, value, feeRate, confirmationTarget, memo })
 
     if (this._config.transactionMaxFee !== undefined && tx.fee > this._config.transactionMaxFee) {
       throw new Error('Exceeded maximum fee cost for transaction operation.')
@@ -441,12 +468,17 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
   }
 
   /** @private */
-  async _getRawTransaction ({ utxos, to, value, fee, feeRate, changeValue }) {
+  async _getRawTransaction ({ utxos, to, value, fee, feeRate, changeValue, memo }) {
     feeRate = this._toBigInt(feeRate)
     if (feeRate < 1n) feeRate = 1n
     value = this._toBigInt(value)
     changeValue = this._toBigInt(changeValue)
     fee = this._toBigInt(fee)
+
+    const memoBytes = _normalizeMemo(memo)
+    const opReturnScript = memoBytes
+      ? payments.embed({ data: [memoBytes] }).output
+      : null
 
     const legacyPrevTxCache = new Map()
     const getPrevTxHex = async (txid) => {
@@ -489,6 +521,7 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
 
       psbt.addOutput({ address: to, value: rcptVal })
       if (chgVal > 0n) psbt.addOutput({ address: await this.getAddress(), value: chgVal })
+      if (opReturnScript) psbt.addOutput({ script: opReturnScript, value: 0n })
 
       utxos.forEach((_, index) => psbt.signInputHD(index, this._masterNode))
       psbt.finalizeAllInputs()
@@ -534,17 +567,18 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc {
   }
 
   /** @private */
-  async _buildSignedTransaction ({ to, value, feeRate, confirmationTarget = 1 }) {
+  async _buildSignedTransaction ({ to, value, feeRate, confirmationTarget = 1, memo }) {
     await this._ensureConnected()
     const address = await this.getAddress()
     if (!feeRate) {
       const feeEstimate = await this._client.estimateFee(confirmationTarget)
       feeRate = this._toBigInt(Math.max(feeEstimate * 100_000, 1))
     }
+    const memoBytes = _normalizeMemo(memo)
     const { utxos, fee, changeValue } = await this._planSpend({
-      fromAddress: address, toAddress: to, amount: value, feeRate
+      fromAddress: address, toAddress: to, amount: value, feeRate, memo: memoBytes
     })
-    const tx = await this._getRawTransaction({ utxos, to, value, fee, feeRate, changeValue })
+    const tx = await this._getRawTransaction({ utxos, to, value, fee, feeRate, changeValue, memo: memoBytes })
     return { tx, utxos }
   }
 }

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -51,6 +51,7 @@ const bitcoinMessage = MessageFactory(ecc)
  * @property {number | bigint} value - The amount of bitcoins to send to the recipient (in satoshis).
  * @property {number} [confirmationTarget] - Optional confirmation target in blocks (default: 1).
  * @property {number | bigint} [feeRate] - Optional fee rate in satoshis per virtual byte. If provided, this value overrides the fee rate estimated from the blockchain (default: undefined).
+ * @property {string | Uint8Array | Buffer} [memo] - Optional OP_RETURN memo payload. Strings are UTF-8 encoded; binary buffers are used verbatim. Capped at 80 bytes (Bitcoin Core's standardness relay limit).
  */
 
 /**
@@ -98,6 +99,22 @@ const { Output } = DescriptorsFactory(ecc)
 
 const MIN_TX_FEE_SATS = 141
 const MAX_UTXO_INPUTS = 200
+
+// Tx-level vbytes contributed by an OP_RETURN output carrying `dataLen`
+// bytes of payload:
+//   8  (value u64)
+// + 1  (script-length varint — always 1 byte for OP_RETURN scripts)
+// + 1  (OP_RETURN opcode)
+// + 1  (OP_PUSHBYTES_n for n ≤ 75, OP_PUSHDATA1 for 76 ≤ n ≤ 80)
+// + 1  (extra byte for OP_PUSHDATA1's length prefix when n ≥ 76)
+// + n  (payload)
+// Upper-bounded by `12 + dataLen` for n ≤ 75 and `13 + dataLen` for
+// 76 ≤ n ≤ 80; we use the larger of the two so coin-selection always
+// over-provisions rather than under-provisions the fee.
+export function _opReturnVBytes (dataLen) {
+  if (!dataLen || dataLen <= 0) return 0
+  return dataLen >= 76 ? 13 + dataLen : 12 + dataLen
+}
 
 const BIP_BY_ADDRESS_PREFIX = {
   1: 44,
@@ -208,7 +225,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
    * @param {BtcTransaction} tx - The transaction.
    * @returns {Promise<Omit<TransactionResult, 'hash'>>} The transaction's quotes.
    */
-  async quoteSendTransaction ({ to, value, feeRate, confirmationTarget = 1 }) {
+  async quoteSendTransaction ({ to, value, feeRate, confirmationTarget = 1, memo }) {
     await this._ensureConnected()
 
     const address = await this.getAddress()
@@ -222,7 +239,8 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
       fromAddress: address,
       toAddress: to,
       amount: value,
-      feeRate
+      feeRate,
+      memo
     })
 
     return { fee: BigInt(fee) }
@@ -277,6 +295,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
    *
    * @param {Object} [opts] - Options.
    * @param {number | bigint} [opts.feeRate] - Fee rate in sat/vB. If omitted, estimated via the client.
+   * @param {string | Uint8Array | Buffer} [opts.memo] - Optional OP_RETURN memo bytes to account for. When supplied, the spendable target leaves room for the OP_RETURN output.
    * @returns {Promise<BtcMaxSpendableResult>} The estimated maximum spendable result.
    */
   async getMaxSpendable (opts = {}) {
@@ -321,7 +340,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     const txOverheadVBytes = 11
     const outputVBytes = 34
 
-    const twoOutputsVSize = txOverheadVBytes + (inputCount * inputVBytes) + (2 * outputVBytes)
+    const memoVBytes = opts.memo !== undefined && opts.memo !== null
+      ? _opReturnVBytes(typeof opts.memo === 'string'
+        ? Buffer.byteLength(opts.memo, 'utf8')
+        : opts.memo.length)
+      : 0
+
+    const twoOutputsVSize = txOverheadVBytes + (inputCount * inputVBytes) + (2 * outputVBytes) + memoVBytes
     const twoOutputsFeeSats = Math.max(Math.ceil(twoOutputsVSize * feeRate), MIN_TX_FEE_SATS)
     const twoOutputsRecipientAmountSats = totalInputValueSats - twoOutputsFeeSats - Number(this._dustLimit)
     if (twoOutputsRecipientAmountSats > Number(this._dustLimit)) {
@@ -332,7 +357,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
       }
     }
 
-    const oneOutputVSize = txOverheadVBytes + (inputCount * inputVBytes) + outputVBytes
+    const oneOutputVSize = txOverheadVBytes + (inputCount * inputVBytes) + outputVBytes + memoVBytes
     const oneOutputFeeSats = Math.max(Math.ceil(oneOutputVSize * feeRate), MIN_TX_FEE_SATS)
     const oneOutputRecipientAmountSats = totalInputValueSats - oneOutputFeeSats
     if (oneOutputRecipientAmountSats <= this._dustLimit) {
@@ -445,9 +470,10 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
    * @param {string} tx.toAddress - The recipient's address.
    * @param {number | bigint} tx.amount - The amount to send (in satoshis).
    * @param {number | bigint} tx.feeRate - The fee rate (in sats/vB).
+   * @param {string | Uint8Array | Buffer} [tx.memo] - Optional OP_RETURN memo bytes; when supplied, the fee is padded for the extra output.
    * @returns {Promise<{ utxos: OutputWithValue[], fee: number, changeValue: number }>} - The funding plan.
    */
-  async _planSpend ({ fromAddress, toAddress, amount, feeRate }) {
+  async _planSpend ({ fromAddress, toAddress, amount, feeRate, memo }) {
     amount = this._toBigInt(amount)
     feeRate = this._toBigInt(feeRate)
     if (feeRate < 1n) feeRate = 1n
@@ -455,6 +481,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     if (amount <= this._dustLimit) {
       throw new Error(`The amount must be bigger than the dust limit (= ${this._dustLimit}).`)
     }
+
+    const memoBytesLen = memo === undefined || memo === null
+      ? 0
+      : (typeof memo === 'string' ? Buffer.byteLength(memo, 'utf8') : memo.length)
+    const opReturnFee = memoBytesLen > 0
+      ? this._toBigInt(Math.ceil(_opReturnVBytes(memoBytesLen) * Number(feeRate)))
+      : 0n
 
     const network = this._network
 
@@ -489,7 +522,11 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
       throw new Error('Exceeded maximum allowed inputs for transaction.')
     }
 
-    const fee = result.fee > BigInt(MIN_TX_FEE_SATS) ? result.fee : BigInt(MIN_TX_FEE_SATS)
+    // coinselect was unaware of the OP_RETURN output (it isn't a
+    // spendable target); pad the fee here so the change covers it. If
+    // the inputs don't cover the bump, fall through to the existing
+    // insufficient-balance branch below.
+    const fee = (result.fee > BigInt(MIN_TX_FEE_SATS) ? result.fee : BigInt(MIN_TX_FEE_SATS)) + opReturnFee
 
     const utxos = result.utxos.map(({ __ref }) => ({
       ...__ref,

--- a/tests/integration/op-return.integration.test.js
+++ b/tests/integration/op-return.integration.test.js
@@ -1,0 +1,88 @@
+// Integration test for OP_RETURN memo on a regtest node.
+//
+// Place at: tests/integration/op-return.integration.test.js in the
+// wdk-wallet-btc repo. Run with: npm run test:integration.
+//
+// Requires a regtest Bitcoin Core node + Electrs (or equivalent
+// Electrum-protocol server) wired into the existing integration
+// harness. Mirrors the existing transfer / sendTransaction integration
+// tests' setup pattern; consult repo conventions for the harness API.
+
+import WalletManagerBtc from '../../index.js'
+
+const REGTEST_MNEMONIC = process.env.REGTEST_MNEMONIC ||
+  'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about'
+const REGTEST_ELECTRUM_HOST = process.env.REGTEST_ELECTRUM_HOST || '127.0.0.1'
+const REGTEST_ELECTRUM_PORT = Number(process.env.REGTEST_ELECTRUM_PORT || 60_001)
+
+const REGTEST_CONFIG = {
+  network: 'regtest',
+  client: {
+    type: 'electrum',
+    clientConfig: { host: REGTEST_ELECTRUM_HOST, port: REGTEST_ELECTRUM_PORT }
+  }
+}
+
+describe('sendTransaction with OP_RETURN memo (regtest)', () => {
+  let wallet
+  let account
+
+  beforeAll(async () => {
+    wallet = new WalletManagerBtc({
+      seed: REGTEST_MNEMONIC,
+      ...REGTEST_CONFIG
+    })
+    account = await wallet.getAccount(0)
+    // The existing integration harness funds this address via
+    // `generatetoaddress`. Skip this test if the address is empty.
+    const balance = await account.getBalance()
+    if (balance.confirmed === 0n) {
+      throw new Error('Regtest address is unfunded — fund via generatetoaddress before running')
+    }
+  })
+
+  afterAll(async () => {
+    await account?.dispose?.()
+    await wallet?.dispose?.()
+  })
+
+  test('emits an OP_RETURN output carrying the memo bytes', async () => {
+    const memo = '=:e:0xabcdef:1234:commission/SDK:444/5'
+    const recipient = await (await wallet.getAccount(1)).getAddress()
+
+    const { hash } = await account.sendTransaction({
+      to: recipient,
+      value: 100_000n,
+      feeRate: 5n,
+      memo
+    })
+
+    // Wait for the tx to be observable, then decode it.
+    const receipt = await new Promise((resolve, reject) => {
+      const deadline = Date.now() + 30_000
+      const poll = async () => {
+        const r = await account.getTransactionReceipt(hash).catch(() => null)
+        if (r) return resolve(r)
+        if (Date.now() > deadline) return reject(new Error('Timed out'))
+        setTimeout(poll, 500)
+      }
+      poll()
+    })
+
+    const opReturn = receipt.outs.find(o => o.script[0] === 0x6a)
+    expect(opReturn).toBeDefined()
+    expect(opReturn.value).toBe(0)
+    const dataOffset = opReturn.script[1] === 0x4c ? 3 : 2
+    expect(opReturn.script.slice(dataOffset).toString('utf8')).toBe(memo)
+  })
+
+  test('rejects memos above the 80-byte standardness cap', async () => {
+    const recipient = await (await wallet.getAccount(1)).getAddress()
+    await expect(account.sendTransaction({
+      to: recipient,
+      value: 100_000n,
+      feeRate: 5n,
+      memo: 'x'.repeat(81)
+    })).rejects.toThrow(RangeError)
+  })
+})

--- a/tests/op-return-unit.test.js
+++ b/tests/op-return-unit.test.js
@@ -1,0 +1,101 @@
+// Unit tests for the OP_RETURN memo support added to
+// WalletAccountBtc.sendTransaction / signTransaction.
+//
+// Place at: tests/op-return-unit.test.js in the wdk-wallet-btc repo.
+// Run with: npm run test:unit
+
+import { payments } from 'bitcoinjs-lib'
+
+import { _normalizeMemo, MAX_OP_RETURN_BYTES } from '../src/wallet-account-btc.js'
+import { _opReturnVBytes } from '../src/wallet-account-read-only-btc.js'
+
+const SAMPLE_MEMO = '=:e:0xe89E630553e63EA65b65F1cA2ea2C50cCA8f3E54:32324827:commission/SDK:444/5'
+
+describe('_normalizeMemo', () => {
+  test('returns null for undefined / null / empty', () => {
+    expect(_normalizeMemo(undefined)).toBeNull()
+    expect(_normalizeMemo(null)).toBeNull()
+    expect(_normalizeMemo('')).toBeNull()
+  })
+
+  test('encodes strings as UTF-8 buffers', () => {
+    const buf = _normalizeMemo('hello')
+    expect(Buffer.isBuffer(buf)).toBe(true)
+    expect(buf.toString('utf8')).toBe('hello')
+    expect(buf.length).toBe(5)
+  })
+
+  test('passes through Buffer inputs', () => {
+    const input = Buffer.from([0x01, 0x02, 0x03])
+    const out = _normalizeMemo(input)
+    expect(out.equals(input)).toBe(true)
+  })
+
+  test('converts Uint8Array inputs to Buffer', () => {
+    const u8 = new Uint8Array([0xaa, 0xbb, 0xcc])
+    const out = _normalizeMemo(u8)
+    expect(Buffer.isBuffer(out)).toBe(true)
+    expect(out.equals(Buffer.from(u8))).toBe(true)
+  })
+
+  test('accepts payloads up to the 80-byte standardness cap', () => {
+    const ok = 'x'.repeat(MAX_OP_RETURN_BYTES)
+    expect(() => _normalizeMemo(ok)).not.toThrow()
+  })
+
+  test('rejects payloads above the 80-byte standardness cap', () => {
+    const tooBig = 'x'.repeat(MAX_OP_RETURN_BYTES + 1)
+    expect(() => _normalizeMemo(tooBig)).toThrow(RangeError)
+  })
+
+  test('accepts a THORChain-style memo (~70 bytes)', () => {
+    const buf = _normalizeMemo(SAMPLE_MEMO)
+    expect(buf).not.toBeNull()
+    expect(buf.length).toBeLessThanOrEqual(MAX_OP_RETURN_BYTES)
+  })
+})
+
+describe('_opReturnVBytes', () => {
+  test('is 0 when no payload', () => {
+    expect(_opReturnVBytes(0)).toBe(0)
+    expect(_opReturnVBytes(undefined)).toBe(0)
+    expect(_opReturnVBytes(null)).toBe(0)
+  })
+
+  test('uses the small-push form for payloads ≤ 75 bytes', () => {
+    expect(_opReturnVBytes(1)).toBe(13)
+    expect(_opReturnVBytes(70)).toBe(82)
+    expect(_opReturnVBytes(75)).toBe(87)
+  })
+
+  test('uses the OP_PUSHDATA1 form for 76 ≤ payload ≤ 80', () => {
+    expect(_opReturnVBytes(76)).toBe(89)
+    expect(_opReturnVBytes(80)).toBe(93)
+  })
+})
+
+describe('OP_RETURN output script (via payments.embed)', () => {
+  test('encodes the small-push form for short memos', () => {
+    const memo = _normalizeMemo('hi')
+    const script = payments.embed({ data: [memo] }).output
+    expect(script[0]).toBe(0x6a) // OP_RETURN
+    expect(script[1]).toBe(memo.length) // direct push opcode
+    expect(script.slice(2).equals(memo)).toBe(true)
+  })
+
+  test('encodes OP_PUSHDATA1 for memos ≥ 76 bytes', () => {
+    const memo = _normalizeMemo('y'.repeat(78))
+    const script = payments.embed({ data: [memo] }).output
+    expect(script[0]).toBe(0x6a) // OP_RETURN
+    expect(script[1]).toBe(0x4c) // OP_PUSHDATA1
+    expect(script[2]).toBe(memo.length)
+    expect(script.slice(3).equals(memo)).toBe(true)
+  })
+
+  test('round-trips the THORChain sample memo bytes verbatim', () => {
+    const memo = _normalizeMemo(SAMPLE_MEMO)
+    const script = payments.embed({ data: [memo] }).output
+    const offset = memo.length < 76 ? 2 : 3
+    expect(script.slice(offset).toString('utf8')).toBe(SAMPLE_MEMO)
+  })
+})


### PR DESCRIPTION
# Description

Adds an optional memo field to signTransaction / sendTransaction on WalletAccountBtc. When supplied, an OP_RETURN output carrying the memo bytes is appended to the PSBT (value 0). Rejected with RangeError if the payload exceeds 80 bytes (Bitcoin Core's MAX_OP_RETURN_RELAY standardness limit).

Threaded through the full transaction-construction path:

- WalletAccountBtc.signTransaction({ …, memo }) — new optional field.
- WalletAccountBtc.sendTransaction({ …, memo }, timeoutMs) — new optional field.
- WalletAccountBtc._buildSignedTransaction({ …, memo }) — internal.
- WalletAccountBtc._getRawTransaction({ …, memo }) — internal; appends the OP_RETURN output to the PSBT after the recipient and change outputs, before signing.
- WalletAccountReadOnlyBtc.quoteSendTransaction({ …, memo }) — new optional field; fee quote accounts for the extra output.
- WalletAccountReadOnlyBtc.getMaxSpendable({ memo }) — new optional option; spendable target leaves room for the OP_RETURN.
- WalletAccountReadOnlyBtc._planSpend({ …, memo }) — pads the coin-selected fee by the OP_RETURN output's vbytes.

Two new exported helpers on the account modules:

- MAX_OP_RETURN_BYTES = 80 (constant) — the standardness cap.
- _normalizeMemo(memo) (validator) — coerces string | Uint8Array | Buffer | null | undefined to a Buffer or null; UTF-8 encodes strings; throws RangeError on oversize input.
- _opReturnVBytes(dataLen) (helper) — tx-level vbytes contributed by an OP_RETURN output of dataLen bytes; used by _planSpend / getMaxSpendable for fee padding. Upper-bounded to account for the extra OP_PUSHDATA1 length prefix when payloads ≥ 76 bytes.

The BtcTransaction JSDoc typedef in wallet-account-read-only-btc.js is extended with an optional memo property so consumer type checkers pick it up.

Backwards-compatible: callers who don't pass memo see no behaviour change. memo === '' or memo === null is treated as omitted.

## Motivation and Context

THORChain and MAYAChain use the tx memo as their primary routing channel: a BTC transfer to an inbound vault with an OP_RETURN memo like "=:ETH.ETH:0xRecipient:min_out" triggers a cross-chain swap; the same transfer with an empty (or absent) memo silently loses the funds to the vault. Currently @tetherto/wdk-wallet-btc doesn't expose any way to attach an OP_RETURN output through its public API, so downstream consumers who want to originate THORChain / MAYAChain deposits have to reach into bitcoinjs-lib themselves, re-implementing PSBT construction, coin selection, dust checks, fee estimation, and signing — all logic this wallet already provides.

Threading a memo parameter through the existing API is the minimal change that fixes this and keeps consumers on the wallet abstraction (private key never leaves the wallet).

Reference downstream use-case: @swapdk/wdk-protocol-bridge-swapdk-btc — cross-chain swaps from BTC to EVM / TRON / other chains, in production against THORChain.

## Related Issue
No pre-existing issue filed against this repository; opened directly as a draft PR to invite feedback on the API shape (memo as an optional field on the existing BtcTransaction object vs. any alternative surfacing the maintainer prefers). Happy to file a companion issue if that's the preferred flow.

Related work in the same repo family:

- @tetherto/wdk-wallet-btc#95 (open) — accepts pre-signed hex on sendTransaction. Different use-case (offline signing → broadcast, vs. inline OP_RETURN attach at build time); discriminators don't collide (typeof tx === 'string' vs. an optional field on the object). Linear conflict on sendTransaction / quoteSendTransaction / _buildSignedTransaction bodies is expected; we're happy to defer / rebase in whichever order the maintainer prefers. Cross-visibility comment posted on that PR.

PR fixes the following issue: N/A (no upstream issue filed).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
