### PR TITLE
Release: v1.0.0-beta.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet-btc",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet-btc",
-      "version": "1.0.0-beta.10",
+      "version": "1.0.0-beta.11",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/btcmessage": "4.0.1",
@@ -16,7 +16,7 @@
         "@mempool/electrum-client": "1.1.9",
         "@noble/hashes": "^1.8.0",
         "@tetherto/wdk-failover-provider": "1.0.0-beta.2",
-        "@tetherto/wdk-wallet": "1.0.0-beta.12",
+        "@tetherto/wdk-wallet": "1.0.0-beta.13",
         "bare-node-runtime": "^1.5.0",
         "bip32": "5.0.1",
         "bip39": "3.1.0",
@@ -65,7 +65,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -1287,9 +1286,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@tetherto/wdk-wallet": {
-      "version": "1.0.0-beta.12",
-      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.12.tgz",
-      "integrity": "sha512-mKMezkFwyoQ84vbnOlJ/zgSinU93Uvyu8wR4aqbcmZiFUTEdnHNV1rlv7h5LCMDS8mKI2EYaXQbw/nbqT3zJVg==",
+      "version": "1.0.0-beta.13",
+      "resolved": "https://registry.npmjs.org/@tetherto/wdk-wallet/-/wdk-wallet-1.0.0-beta.13.tgz",
+      "integrity": "sha512-0lF6TVxcgui/uLpU54x+3+qcAiypiMhJhnHbnHlyCxwKNjpzncq2DsJwJg/IeyeH1mm2wKWE4QqOohRr/VQbwA==",
       "license": "Apache-2.0",
       "dependencies": {
         "bare-node-runtime": "^1.4.0",
@@ -1432,7 +1431,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1853,7 +1851,6 @@
       "resolved": "https://registry.npmjs.org/bare-abort-controller/-/bare-abort-controller-1.0.0.tgz",
       "integrity": "sha512-RSUPsS16TC0EfqfjZUlQwLAtFCUUl7NA0CYaE4/Sl9ExFx3q0WIogBHmW5Zn16NRZUHDJqEffmtnvIyw6LFUjA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-events": "^2.7.0"
       }
@@ -2584,7 +2581,6 @@
       "resolved": "https://registry.npmjs.org/bare-tcp/-/bare-tcp-2.5.0.tgz",
       "integrity": "sha512-lwUy3jSVoloVBbCCyPFmmqT1KaeBk/XEkpLMHU+BCap8WNXc48iQfiWEQYgJkCRYuP6vnkZ0XHCLY222TJ29Wg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "bare-dns": "^2.0.4",
         "bare-events": "^2.5.4",
@@ -2895,7 +2891,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.38",
         "caniuse-lite": "^1.0.30001799",
@@ -3704,7 +3699,6 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -3912,7 +3906,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -3970,7 +3963,6 @@
       "integrity": "sha512-jDex9s7D/Qial8AGVIHq4W7NswpUD5DPDL2RH8Lzd9EloWUuvUkHfv4FRLMipH5q2UtyurorBkPeNi1wVWNh3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "builtins": "^5.0.1",
         "eslint-plugin-es": "^4.1.0",
@@ -4010,7 +4002,6 @@
       "integrity": "sha512-57Zzfw8G6+Gq7axm2Pdo3gW/Rx3h9Yywgn61uE/3elTCOePEHVrn2i5CdfBwA1BLK0Q0WqctICIUSqXZW/VprQ==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
@@ -4027,7 +4018,6 @@
       "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -6272,9 +6262,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet-btc",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "description": "A simple package to manage BIP-32 wallets for the bitcoin blockchain.",
   "keywords": [
     "wdk",
@@ -35,7 +35,7 @@
     "@bitcoinerlab/secp256k1": "1.2.0",
     "@mempool/electrum-client": "1.1.9",
     "@tetherto/wdk-failover-provider": "1.0.0-beta.2",
-    "@tetherto/wdk-wallet": "1.0.0-beta.12",
+    "@tetherto/wdk-wallet": "1.0.0-beta.13",
     "bare-node-runtime": "^1.5.0",
     "@noble/hashes": "^1.8.0",
     "bip32": "5.0.1",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.11

### Changes since v1.0.0-beta.10
- Upgrade bitcoinjs-lib v7 and BitcoinerLAB v3 dependencies (#93)
- Update sendTransaction and quoteSendTransaction methods for signed txs (#95)
- Declare @noble/hashes ^1.8.0 dependency to prevent resolution to incompatible v2 (#96)

### Dependency updates
- `@tetherto/wdk-wallet`: 1.0.0-beta.12 → 1.0.0-beta.13
- `@tetherto/wdk-failover-provider`: 1.0.0-beta.2 (already latest)
- npm audit fix applied (js-yaml; 0 vulnerabilities remaining)


Made with [Cursor](https://cursor.com)