### PR TITLE
Update balance calculation logic: Confirmed - unconfirmed outgoing

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,9 +124,9 @@ console.log('Custom account address:', customAddress)
 import WalletManagerBtc from '@tetherto/wdk-wallet-btc'
 
 // Assume wallet and account are already created
-// Get confirmed balance (returns confirmed balance only)
+// Get balance in satoshis
 const balance = await account.getBalance()
-console.log('Confirmed balance:', balance, 'satoshis') // 1 BTC = 100,000,000 satoshis
+console.log('Balance:', balance, 'satoshis') // 1 BTC = 100,000,000 satoshis
 
 // Get transfer history (incoming and outgoing transfers)
 const allTransfers = await account.getTransfers()
@@ -145,7 +145,9 @@ console.log('Incoming transfers:', incomingTransfers)
 ```
 
 **Important Notes:**
-- `getBalance()` returns confirmed balance only (no unconfirmed balance option)
+- When the client reports `unconfirmedOutgoing`, unconfirmed incoming funds aren't counted (since they aren't spendable yet) but unconfirmed outgoing funds are subtracted immediately. Clients that can't compute `unconfirmedOutgoing` fall back to netting the raw unconfirmed balance.
+  - **Blockbook** (`blockbook-http`) computes `unconfirmedOutgoing`: a pending spend of yours is subtracted as soon as it's broadcast, following the same trust rule as Bitcoin Core's own wallet - it only counts if every input it draws from is itself confirmed, or comes from another one of your pending transactions that's *also* trusted by that same rule.
+  - **Electrum** (`electrum`, `electrum-ws`) doesn't compute `unconfirmedOutgoing`, so it falls back to the server's raw net mempool delta, which is coarser and can include unconfirmed incoming amounts too. Any client that does implement `unconfirmedOutgoing` should follow Blockbook's same trust rule, so `getBalance()` behaves consistently across providers.
 - There's no direct UTXO access method - UTXOs are managed internally
 - Use `getTransfers()` instead of `getTransactionHistory()` for transaction data
 - Transfer objects include transaction ID, value, direction, fee, and block height information
@@ -349,7 +351,7 @@ new WalletAccountBtc(seed, path, config)
 | Method | Description | Returns |
 |--------|-------------|---------|
 | `getAddress()` | Returns the account's Bitcoin address | `Promise<string>` |
-| `getBalance()` | Returns the confirmed account balance in satoshis | `Promise<bigint>` |
+| `getBalance()` | Returns the account's balance in satoshis (see [Checking Balances](#checking-balances)) | `Promise<bigint>` |
 | `sendTransaction(options)` | Sends a Bitcoin transaction | `Promise<{hash: string, fee: bigint}>` |
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransfers(options?)` | Returns the account's transfer history | `Promise<BtcTransfer[]>` |
@@ -372,7 +374,7 @@ console.log('Address:', address) // bc1q... (BIP-84) or 1... (BIP-44)
 ```
 
 ##### `getBalance()`
-Returns the account's confirmed balance in satoshis.
+Returns the account's balance in satoshis - confirmed funds, plus handling of the account's own pending transactions that varies by provider. See [Checking Balances](#checking-balances) for details.
 
 **Returns:** `Promise<bigint>` - Balance in satoshis
 
@@ -561,7 +563,7 @@ new WalletAccountReadOnlyBtc(address, config)
 
 | Method | Description | Returns |
 |--------|-------------|---------|
-| `getBalance()` | Returns the confirmed account balance in satoshis | `Promise<bigint>` |
+| `getBalance()` | Returns the account's balance in satoshis (see [Checking Balances](#checking-balances)) | `Promise<bigint>` |
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransaction \| null>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<{amount: bigint, fee: bigint, changeValue: bigint}>` |

--- a/src/transports/blockbook-client.js
+++ b/src/transports/blockbook-client.js
@@ -22,22 +22,26 @@ const MEMPOOL_SPACE_URL = 'https://mempool.space'
 
 /**
  * Sums the amount leaving an address through its unconfirmed transactions,
- * excluding change returned to the same address.
+ * excluding change returned to the same address and inputs that spend the
+ * address's own other unconfirmed transactions (0-conf chaining), since that
+ * value was never part of the confirmed balance to begin with.
  *
  * @param {Array<Object>} [transactions] - Transactions returned for the address.
  * @param {string} address - The bitcoin address.
  * @returns {number} Unconfirmed outgoing amount in satoshis.
  */
 function getUnconfirmedOutgoing (transactions, address) {
-  return (transactions || [])
-    .filter(tx => tx.blockHeight === -1)
-    .reduce((total, tx) => {
-      const spent = sumOwnedValues(tx.vin, address)
-      if (spent === 0) return total
+  const pending = (transactions || []).filter(tx => tx.blockHeight === -1)
+  const pendingTxids = new Set(pending.map(tx => tx.txid))
 
-      const change = sumOwnedValues(tx.vout, address)
-      return total + (spent - change)
-    }, 0)
+  return pending.reduce((total, tx) => {
+    const vin = (tx.vin || []).filter(entry => !pendingTxids.has(entry.txid))
+    const spent = sumOwnedValues(vin, address)
+    if (spent === 0) return total
+
+    const change = sumOwnedValues(tx.vout, address)
+    return total + (spent - change)
+  }, 0)
 }
 
 /**

--- a/src/transports/blockbook-client.js
+++ b/src/transports/blockbook-client.js
@@ -21,6 +21,37 @@
 const MEMPOOL_SPACE_URL = 'https://mempool.space'
 
 /**
+ * Sums the amount leaving an address through its unconfirmed transactions,
+ * excluding change returned to the same address.
+ *
+ * @param {Array<Object>} [transactions] - Transactions returned for the address.
+ * @param {string} address - The bitcoin address.
+ * @returns {number} Unconfirmed outgoing amount in satoshis.
+ */
+function getUnconfirmedOutgoing (transactions, address) {
+  return (transactions || [])
+    .filter(tx => tx.blockHeight === -1)
+    .reduce((total, tx) => {
+      const spent = sumOwnedValues(tx.vin, address)
+      if (spent === 0) return total
+
+      const change = sumOwnedValues(tx.vout, address)
+      return total + (spent - change)
+    }, 0)
+}
+
+/**
+ * @param {Array<Object>} [entries] - Transaction vin or vout entries.
+ * @param {string} address - The bitcoin address.
+ * @returns {number} Sum of entry values belonging to the address.
+ */
+function sumOwnedValues (entries, address) {
+  return (entries || [])
+    .filter(entry => entry.isAddress && entry.addresses?.includes(address))
+    .reduce((total, entry) => total + Number(entry.value), 0)
+}
+
+/**
  * @typedef {Object} BlockbookClientConfig
  * @property {string} url - The Blockbook server API base URL (e.g., 'https://btc1.trezor.io/api').
  */
@@ -77,11 +108,14 @@ export default class BlockbookClient {
    * @returns {Promise<BtcBalance>} The balance information.
    */
   async getBalance (address) {
-    const data = await this._get(`/v2/address/${address}?details=basic`)
+    const data = await this._get(`/v2/address/${address}?details=txs`)
+
+    const unconfirmedOutgoing = getUnconfirmedOutgoing(data.transactions, address)
 
     return {
       confirmed: Number(data.balance),
-      unconfirmed: Number(data.unconfirmedBalance)
+      unconfirmed: Number(data.unconfirmedBalance),
+      unconfirmedOutgoing
     }
   }
 

--- a/src/transports/blockbook-client.js
+++ b/src/transports/blockbook-client.js
@@ -21,25 +21,64 @@
 const MEMPOOL_SPACE_URL = 'https://mempool.space'
 
 /**
- * Sums the amount leaving an address through its unconfirmed transactions,
- * excluding change returned to the same address and inputs that spend the
- * address's own other unconfirmed transactions (0-conf chaining), since that
- * value was never part of the confirmed balance to begin with.
+ * Sums the amount leaving an address through its unconfirmed transactions.
  *
  * @param {Array<Object>} [transactions] - Transactions returned for the address.
  * @param {string} address - The bitcoin address.
  * @returns {number} Unconfirmed outgoing amount in satoshis.
  */
 function getUnconfirmedOutgoing (transactions, address) {
-  const pending = (transactions || []).filter(tx => tx.blockHeight === -1)
-  const pendingTxids = new Set(pending.map(tx => tx.txid))
+  const pendingTxs = (transactions || []).filter(tx => tx.blockHeight === -1)
+  const pendingTxids = new Set(pendingTxs.map(tx => tx.txid))
+  const pendingTxsById = new Map(pendingTxs.map(tx => [tx.txid, tx]))
 
-  return pending.reduce((total, tx) => {
+  const rootedTxMap = new Map()
+
+  // A tx only counts if its money traces back to confirmed funds - directly,
+  // or by spending another pending tx that is itself rooted. A tx built
+  // entirely from other unconfirmed deposits (nothing rooted upstream) is
+  // ignored, since none of that value was ever part of the confirmed balance.
+  function isRooted (tx) {
+    if (rootedTxMap.has(tx.txid)) return rootedTxMap.get(tx.txid)
+
+    // Assume unrooted while resolving, to guard against any (invalid) cycle.
+    rootedTxMap.set(tx.txid, false)
+
+    const ownedVins = (tx.vin || []).filter(entry => entry.isAddress && entry.addresses?.includes(address))
+
+    const rooted = ownedVins.some(vin => {
+      if (!pendingTxids.has(vin.txid)) return true // spends an already-confirmed output
+
+      const parent = pendingTxsById.get(vin.txid)
+      return isRooted(parent)
+    })
+
+    rootedTxMap.set(tx.txid, rooted)
+    return rooted
+  }
+
+  const rootedTxs = pendingTxs.filter(isRooted)
+
+  // Track every pending output that gets spent further by another rooted tx,
+  // so it's excluded from change below - only the final, unspent tip of a
+  // chain should count as change, not an intermediate hop.
+  const consumedOutpoints = new Set()
+  for (const tx of rootedTxs) {
+    for (const vin of tx.vin || []) {
+      if (pendingTxids.has(vin.txid)) consumedOutpoints.add(`${vin.txid}:${vin.vout}`)
+    }
+  }
+
+  return rootedTxs.reduce((total, tx) => {
+    // Exclude inputs that spend another pending tx's output - that value is
+    // already accounted for by whichever tx produced it (or was never real,
+    // if that tx isn't rooted).
     const vin = (tx.vin || []).filter(entry => !pendingTxids.has(entry.txid))
     const spent = sumOwnedValues(vin, address)
-    if (spent === 0) return total
 
-    const change = sumOwnedValues(tx.vout, address)
+    const vout = (tx.vout || []).filter(entry => !consumedOutpoints.has(`${tx.txid}:${entry.n}`))
+    const change = sumOwnedValues(vout, address)
+
     return total + (spent - change)
   }, 0)
 }

--- a/src/transports/blockbook-client.js
+++ b/src/transports/blockbook-client.js
@@ -23,6 +23,14 @@ const MEMPOOL_SPACE_URL = 'https://mempool.space'
 /**
  * Sums the amount leaving an address through its unconfirmed transactions.
  *
+ * Follows the same trust rule as Bitcoin Core's own wallet (see
+ * `CachedTxIsTrusted` in https://github.com/bitcoin/bitcoin/blob/master/src/wallet/receive.cpp):
+ * a pending transaction only counts if every one of its address-owned inputs
+ * is either already confirmed, or itself spends another pending transaction
+ * that is also trusted by this same rule. A transaction with even one
+ * untrusted input (e.g. mixing in an unconfirmed deposit from elsewhere) gets
+ * no credit for its own change until the whole chain resolves.
+ *
  * @param {Array<Object>} [transactions] - Transactions returned for the address.
  * @param {string} address - The bitcoin address.
  * @returns {number} Unconfirmed outgoing amount in satoshis.
@@ -32,52 +40,51 @@ function getUnconfirmedOutgoing (transactions, address) {
   const pendingTxids = new Set(pendingTxs.map(tx => tx.txid))
   const pendingTxsById = new Map(pendingTxs.map(tx => [tx.txid, tx]))
 
-  const rootedTxMap = new Map()
+  const trustedTxMap = new Map()
 
-  // A tx only counts if its money traces back to confirmed funds - directly,
-  // or by spending another pending tx that is itself rooted. A tx built
-  // entirely from other unconfirmed deposits (nothing rooted upstream) is
-  // ignored, since none of that value was ever part of the confirmed balance.
-  function isRooted (tx) {
-    if (rootedTxMap.has(tx.txid)) return rootedTxMap.get(tx.txid)
+  // Matches Bitcoin Core's own wallet policy: a pending tx is only trusted if
+  // it has an address-owned input, and every one of them is either already
+  // confirmed or chained from another trusted tx. A tx with even one
+  // untrusted input (e.g. mixing in an unconfirmed deposit from elsewhere)
+  // gets no credit for its own change until the whole thing is trusted.
+  function isTrusted (tx) {
+    if (trustedTxMap.has(tx.txid)) return trustedTxMap.get(tx.txid)
 
-    // Assume unrooted while resolving, to guard against any (invalid) cycle.
-    rootedTxMap.set(tx.txid, false)
+    // Assume untrusted while resolving, to guard against any (invalid) cycle.
+    trustedTxMap.set(tx.txid, false)
 
     const ownedVins = (tx.vin || []).filter(entry => entry.isAddress && entry.addresses?.includes(address))
 
-    const rooted = ownedVins.some(vin => {
+    const trusted = ownedVins.length > 0 && ownedVins.every(vin => {
       if (!pendingTxids.has(vin.txid)) return true // spends an already-confirmed output
 
       const parent = pendingTxsById.get(vin.txid)
-      return isRooted(parent)
+      return isTrusted(parent)
     })
 
-    rootedTxMap.set(tx.txid, rooted)
-    return rooted
+    trustedTxMap.set(tx.txid, trusted)
+    return trusted
   }
 
-  const rootedTxs = pendingTxs.filter(isRooted)
-
-  // Track every pending output that gets spent further by another rooted tx,
-  // so it's excluded from change below - only the final, unspent tip of a
-  // chain should count as change, not an intermediate hop.
+  // Track every pending output that gets spent further by another tx, so
+  // it's excluded from change below - only the final, unspent tip of a chain
+  // should count as change, not an intermediate hop.
   const consumedOutpoints = new Set()
-  for (const tx of rootedTxs) {
+  for (const tx of pendingTxs) {
     for (const vin of tx.vin || []) {
       if (pendingTxids.has(vin.txid)) consumedOutpoints.add(`${vin.txid}:${vin.vout}`)
     }
   }
 
-  return rootedTxs.reduce((total, tx) => {
-    // Exclude inputs that spend another pending tx's output - that value is
-    // already accounted for by whichever tx produced it (or was never real,
-    // if that tx isn't rooted).
+  return pendingTxs.reduce((total, tx) => {
+    // Any input spending another pending tx's output is already accounted
+    // for by whichever tx produced it - only a directly confirmed spend
+    // counts here, regardless of whether this tx is trusted.
     const vin = (tx.vin || []).filter(entry => !pendingTxids.has(entry.txid))
     const spent = sumOwnedValues(vin, address)
 
     const vout = (tx.vout || []).filter(entry => !consumedOutpoints.has(`${tx.txid}:${entry.n}`))
-    const change = sumOwnedValues(vout, address)
+    const change = isTrusted(tx) ? sumOwnedValues(vout, address) : 0
 
     return total + (spent - change)
   }, 0)

--- a/src/transports/blockbook-client.js
+++ b/src/transports/blockbook-client.js
@@ -43,7 +43,9 @@ function getUnconfirmedOutgoing (transactions, address) {
   const trustedTxMap = new Map()
 
   // Matches Bitcoin Core's own wallet policy: a pending tx is only trusted if
-  // it has an address-owned input, and every one of them is either already
+  // every one of its inputs is address-owned (not just some of them - a tx
+  // with even one input belonging to someone else, e.g. a shared or
+  // multi-party transaction, is untrusted), and each is either already
   // confirmed or chained from another trusted tx. A tx with even one
   // untrusted input (e.g. mixing in an unconfirmed deposit from elsewhere)
   // gets no credit for its own change until the whole thing is trusted.
@@ -53,9 +55,10 @@ function getUnconfirmedOutgoing (transactions, address) {
     // Assume untrusted while resolving, to guard against any (invalid) cycle.
     trustedTxMap.set(tx.txid, false)
 
-    const ownedVins = (tx.vin || []).filter(entry => entry.isAddress && entry.addresses?.includes(address))
+    const vins = tx.vin || []
+    const ownedVins = vins.filter(entry => entry.isAddress && entry.addresses?.includes(address))
 
-    const trusted = ownedVins.length > 0 && ownedVins.every(vin => {
+    const trusted = vins.length > 0 && ownedVins.length === vins.length && ownedVins.every(vin => {
       if (!pendingTxids.has(vin.txid)) return true // spends an already-confirmed output
 
       const parent = pendingTxsById.get(vin.txid)

--- a/src/transports/btc-client.js
+++ b/src/transports/btc-client.js
@@ -25,6 +25,7 @@ import { address as btcAddress, crypto } from 'bitcoinjs-lib'
  * @typedef {Object} BtcBalance
  * @property {number} confirmed - Confirmed balance in satoshis.
  * @property {number} [unconfirmed] - Unconfirmed balance in satoshis.
+ * @property {number} [unconfirmedOutgoing] - Amount leaving the address through unconfirmed transactions, in satoshis.
  */
 
 /**

--- a/src/transports/btc-client.js
+++ b/src/transports/btc-client.js
@@ -26,6 +26,8 @@ import { address as btcAddress, crypto } from 'bitcoinjs-lib'
  * @property {number} confirmed - Confirmed balance in satoshis.
  * @property {number} [unconfirmed] - Unconfirmed balance in satoshis.
  * @property {number} [unconfirmedOutgoing] - Amount leaving the address through unconfirmed transactions, in satoshis.
+ *   Clients that implement this should follow the same trust rule as {@link BlockbookClient}'s `getUnconfirmedOutgoing`,
+ *   so `getBalance()` behaves consistently regardless of which client backs it.
  */
 
 /**

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -178,8 +178,10 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
   /**
    * Returns the account's bitcoin balance.
    *
-   * Unconfirmed incoming funds aren't counted, since they aren't spendable
-   * yet. Unconfirmed outgoing funds are subtracted immediately
+   * When the client reports unconfirmedOutgoing, unconfirmed incoming funds
+   * aren't counted (since they aren't spendable yet) but unconfirmed
+   * outgoing funds are subtracted immediately. Clients that can't compute
+   * unconfirmedOutgoing fall back to netting the raw unconfirmed balance.
    *
    * @returns {Promise<bigint>} The bitcoin balance (in satoshis).
    */
@@ -188,9 +190,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 
     const address = await this.getAddress()
 
-    const { confirmed, unconfirmedOutgoing } = await this._client.getBalance(address)
+    const { confirmed, unconfirmed, unconfirmedOutgoing } = await this._client.getBalance(address)
 
-    return BigInt(confirmed - (unconfirmedOutgoing || 0))
+    if (unconfirmedOutgoing !== undefined) {
+      return BigInt(confirmed - unconfirmedOutgoing)
+    }
+
+    return BigInt(confirmed + (unconfirmed || 0))
   }
 
   /**

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -178,6 +178,9 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
   /**
    * Returns the account's bitcoin balance.
    *
+   * Unconfirmed incoming funds aren't counted, since they aren't spendable
+   * yet. Unconfirmed outgoing funds are subtracted immediately
+   * 
    * @returns {Promise<bigint>} The bitcoin balance (in satoshis).
    */
   async getBalance () {
@@ -185,9 +188,9 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 
     const address = await this.getAddress()
 
-    const { confirmed, unconfirmed } = await this._client.getBalance(address)
+    const { confirmed, unconfirmedOutgoing } = await this._client.getBalance(address)
 
-    return BigInt(confirmed + (unconfirmed || 0))
+    return BigInt(confirmed - (unconfirmedOutgoing || 0))
   }
 
   /**

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -180,7 +180,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
    *
    * Unconfirmed incoming funds aren't counted, since they aren't spendable
    * yet. Unconfirmed outgoing funds are subtracted immediately
-   * 
+   *
    * @returns {Promise<bigint>} The bitcoin balance (in satoshis).
    */
   async getBalance () {

--- a/tests/blockbook-client.test.js
+++ b/tests/blockbook-client.test.js
@@ -42,8 +42,9 @@ describe('BlockbookClient', () => {
         balance: '100000',
         unconfirmedBalance: '50000',
         transactions: [{
+          txid: 'tx1',
           blockHeight: -1,
-          vin: [{ isAddress: true, addresses: ['ANOTHER_MOCK_ADDRESS'], value: '50000' }],
+          vin: [{ isAddress: true, addresses: ['ANOTHER_MOCK_ADDRESS'], value: '50000', txid: 'prev-confirmed-tx' }],
           vout: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }]
         }]
       }))
@@ -58,8 +59,9 @@ describe('BlockbookClient', () => {
         balance: '100000',
         unconfirmedBalance: '-45000',
         transactions: [{
+          txid: 'tx1',
           blockHeight: -1,
-          vin: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }],
+          vin: [{ isAddress: true, addresses: [ADDRESS], value: '50000', txid: 'prev-confirmed-tx' }],
           vout: [
             { isAddress: true, addresses: [ADDRESS], value: '5000' },
             { isAddress: true, addresses: ['MOCK_RECIPIENT'], value: '44000' }
@@ -78,13 +80,15 @@ describe('BlockbookClient', () => {
         unconfirmedBalance: '55000',
         transactions: [
           {
+            txid: 'tx1',
             blockHeight: -1,
-            vin: [{ isAddress: true, addresses: ['someone-else'], value: '200000' }],
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '200000', txid: 'prev-someone-else-tx' }],
             vout: [{ isAddress: true, addresses: [ADDRESS], value: '200000' }]
           },
           {
+            txid: 'tx2',
             blockHeight: -1,
-            vin: [{ isAddress: true, addresses: [ADDRESS], value: '150000' }],
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '150000', txid: 'prev-confirmed-tx' }],
             vout: [
               { isAddress: true, addresses: [ADDRESS], value: '5000' },
               { isAddress: true, addresses: ['recipient'], value: '144000' }
@@ -96,6 +100,66 @@ describe('BlockbookClient', () => {
       const balance = await client.getBalance(ADDRESS)
 
       expect(balance.unconfirmedOutgoing).toBe(145000)
+    })
+
+    test('should not go negative when a pending send spends the address\'s own pending receive (0-conf chaining)', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '0',
+        unconfirmedBalance: '9000',
+        transactions: [
+          {
+            txid: 'tx1',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '50000', txid: 'prev-someone-else-tx' }],
+            vout: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }]
+          },
+          {
+            txid: 'tx2',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '50000', txid: 'tx1' }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '29000' },
+              { isAddress: true, addresses: ['recipient'], value: '20000' }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(0)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
+    })
+
+    test('should only count the confirmed-sourced input when a pending send mixes a confirmed and a chained input', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '500000',
+        unconfirmedBalance: '460000',
+        transactions: [
+          {
+            txid: 'tx1',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '50000', txid: 'prev-someone-else-tx' }],
+            vout: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }]
+          },
+          {
+            txid: 'tx2',
+            blockHeight: -1,
+            vin: [
+              { isAddress: true, addresses: [ADDRESS], value: '500000', txid: 'prev-confirmed-tx' },
+              { isAddress: true, addresses: [ADDRESS], value: '50000', txid: 'tx1' }
+            ],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '40000' },
+              { isAddress: true, addresses: ['recipient'], value: '510000' }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(460000)
     })
 
     test('should ignore confirmed transactions when computing the outgoing amount', async () => {

--- a/tests/blockbook-client.test.js
+++ b/tests/blockbook-client.test.js
@@ -14,6 +14,118 @@ describe('BlockbookClient', () => {
     client = new BlockbookClient({ url: 'https://example.com/api' })
   })
 
+  describe('getBalance', () => {
+    const ADDRESS = 'MOCK_ADDRESS'
+
+    function mockBlockbookAddress (data) {
+      return {
+        ok: true,
+        json: jest.fn().mockResolvedValue(data)
+      }
+    }
+
+    test('should return the confirmed balance with no outgoing when there are no pending transactions', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '100000',
+        unconfirmedBalance: '0',
+        transactions: []
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(fetchMock).toHaveBeenCalledWith(`https://example.com/api/v2/address/${ADDRESS}?details=txs`)
+      expect(balance).toEqual({ confirmed: 100000, unconfirmed: 0, unconfirmedOutgoing: 0 })
+    })
+
+    test('should not count a pending incoming transaction as outgoing', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '100000',
+        unconfirmedBalance: '50000',
+        transactions: [{
+          blockHeight: -1,
+          vin: [{ isAddress: true, addresses: ['ANOTHER_MOCK_ADDRESS'], value: '50000' }],
+          vout: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }]
+        }]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(0)
+    })
+
+    test('should compute the outgoing amount for a pending send with change back to the same address', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '100000',
+        unconfirmedBalance: '-45000',
+        transactions: [{
+          blockHeight: -1,
+          vin: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }],
+          vout: [
+            { isAddress: true, addresses: [ADDRESS], value: '5000' },
+            { isAddress: true, addresses: ['MOCK_RECIPIENT'], value: '44000' }
+          ]
+        }]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(45000)
+    })
+
+    test('should only count the outgoing side when a pending receive and a pending send happen together', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '100000',
+        unconfirmedBalance: '55000',
+        transactions: [
+          {
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '200000' }],
+            vout: [{ isAddress: true, addresses: [ADDRESS], value: '200000' }]
+          },
+          {
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '150000' }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '5000' },
+              { isAddress: true, addresses: ['recipient'], value: '144000' }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(145000)
+    })
+
+    test('should ignore confirmed transactions when computing the outgoing amount', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '100000',
+        unconfirmedBalance: '0',
+        transactions: [{
+          blockHeight: 800000,
+          vin: [{ isAddress: true, addresses: [ADDRESS], value: '50000' }],
+          vout: [{ isAddress: true, addresses: ['recipient'], value: '49000' }]
+        }]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(0)
+    })
+
+    test('should default to no outgoing when the transactions field is missing', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '100000',
+        unconfirmedBalance: '0'
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(0)
+    })
+  })
+
   describe('estimateFee', () => {
     const MEMPOOL_FEES = {
       fastestFee: 50,

--- a/tests/blockbook-client.test.js
+++ b/tests/blockbook-client.test.js
@@ -37,6 +37,7 @@ describe('BlockbookClient', () => {
       expect(balance).toEqual({ confirmed: 100000, unconfirmed: 0, unconfirmedOutgoing: 0 })
     })
 
+    // tx1 only has the address in vout (no vin) - a pure receive, never counted per policy.
     test('should not count a pending incoming transaction as outgoing', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '100000',
@@ -74,6 +75,9 @@ describe('BlockbookClient', () => {
       expect(balance.unconfirmedOutgoing).toBe(45000)
     })
 
+    // tx1: unrelated pending deposit of 200,000 (ignored). tx2: spends a confirmed
+    // 150,000, sends 144,000, keeps 5,000 change - the two are independent, so
+    // only tx2's spend should count.
     test('should only count the outgoing side when a pending receive and a pending send happen together', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '100000',
@@ -102,6 +106,10 @@ describe('BlockbookClient', () => {
       expect(balance.unconfirmedOutgoing).toBe(145000)
     })
 
+    // tx1: unconfirmed deposit of 50,000, not rooted (no vin). tx2: spends that
+    // same still-unconfirmed 50,000, sends 20,000, keeps 29,000 - since nothing
+    // here ever touched confirmed money, the whole chain must net to zero rather
+    // than going negative.
     test('should not go negative when a pending send spends the address\'s own pending receive (0-conf chaining)', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '0',
@@ -131,6 +139,9 @@ describe('BlockbookClient', () => {
       expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
     })
 
+    // tx1: unconfirmed deposit of 50,000, not rooted. tx2: spends a confirmed
+    // 500,000 AND that same unrooted 50,000 together, keeps 40,000 change -
+    // only the confirmed 500,000 side should count as real outgoing.
     test('should only count the confirmed-sourced input when a pending send mixes a confirmed and a chained input', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '500000',
@@ -160,6 +171,120 @@ describe('BlockbookClient', () => {
       const balance = await client.getBalance(ADDRESS)
 
       expect(balance.unconfirmedOutgoing).toBe(460000)
+    })
+
+    // tx1: spends confirmed 1,000,000, sends 300,000, keeps 700,000 change.
+    // tx3: spends that same 700,000, sends 400,000, keeps 300,000 - tx3's
+    // further spend must reduce the balance too, not just tx1's own portion.
+    test('should subtract a further pending spend of a rooted change output instead of double-crediting it', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '1000000',
+        unconfirmedBalance: '-700000',
+        transactions: [
+          {
+            txid: 'tx1',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '1000000', txid: 'prev-confirmed-tx' }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '700000', n: 0 },
+              { isAddress: true, addresses: ['recipient1'], value: '300000', n: 1 }
+            ]
+          },
+          {
+            txid: 'tx3',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '700000', txid: 'tx1', vout: 0 }],
+            vout: [
+              { isAddress: true, addresses: ['recipient2'], value: '400000', n: 0 },
+              { isAddress: true, addresses: [ADDRESS], value: '300000', n: 1 }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(700000)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(300000)
+    })
+
+    // tx1: spends confirmed 300,000, keeps 200,000 change. tx4: spends a
+    // separate confirmed 500,000 AND tx1's 200,000 change together, keeps
+    // 150,000 - both inputs are real, so both should count.
+    test('should count both a direct confirmed input and a chained input from another rooted transaction', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '800000',
+        unconfirmedBalance: '-650000',
+        transactions: [
+          {
+            txid: 'tx1',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '300000', txid: 'confirmed-A' }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '200000', n: 0 },
+              { isAddress: true, addresses: ['recipient1'], value: '100000', n: 1 }
+            ]
+          },
+          {
+            txid: 'tx4',
+            blockHeight: -1,
+            vin: [
+              { isAddress: true, addresses: [ADDRESS], value: '500000', txid: 'confirmed-B' },
+              { isAddress: true, addresses: [ADDRESS], value: '200000', txid: 'tx1', vout: 0 }
+            ],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '150000', n: 0 },
+              { isAddress: true, addresses: ['recipient2'], value: '550000', n: 1 }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(650000)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(150000)
+    })
+
+    // t1: unconfirmed deposit, not rooted. t2 spends t1's output, t3 spends
+    // t2's output - the whole 3-hop chain never touches confirmed money, so
+    // it must net to zero however many hops deep it goes.
+    test('should ignore a multi-hop chain of pending transactions that never touches confirmed money', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '0',
+        unconfirmedBalance: '100000',
+        transactions: [
+          {
+            txid: 't1',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '500000', txid: 'prev-someone-else-tx' }],
+            vout: [{ isAddress: true, addresses: [ADDRESS], value: '500000', n: 0 }]
+          },
+          {
+            txid: 't2',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '500000', txid: 't1', vout: 0 }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '300000', n: 0 },
+              { isAddress: true, addresses: ['recipientA'], value: '200000', n: 1 }
+            ]
+          },
+          {
+            txid: 't3',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '300000', txid: 't2', vout: 0 }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '100000', n: 0 },
+              { isAddress: true, addresses: ['recipientB'], value: '200000', n: 1 }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(0)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
     })
 
     test('should ignore confirmed transactions when computing the outgoing amount', async () => {

--- a/tests/blockbook-client.test.js
+++ b/tests/blockbook-client.test.js
@@ -106,7 +106,7 @@ describe('BlockbookClient', () => {
       expect(balance.unconfirmedOutgoing).toBe(145000)
     })
 
-    // tx1: unconfirmed deposit of 50,000, not rooted (no vin). tx2: spends that
+    // tx1: unconfirmed deposit of 50,000, not trusted (no vin). tx2: spends that
     // same still-unconfirmed 50,000, sends 20,000, keeps 29,000 - since nothing
     // here ever touched confirmed money, the whole chain must net to zero rather
     // than going negative.
@@ -139,10 +139,11 @@ describe('BlockbookClient', () => {
       expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
     })
 
-    // tx1: unconfirmed deposit of 50,000, not rooted. tx2: spends a confirmed
-    // 500,000 AND that same unrooted 50,000 together, keeps 40,000 change -
-    // only the confirmed 500,000 side should count as real outgoing.
-    test('should only count the confirmed-sourced input when a pending send mixes a confirmed and a chained input', async () => {
+    // tx1: unconfirmed deposit of 50,000, not trusted. tx2: spends a confirmed
+    // 500,000 AND that same untrusted 50,000 together, keeps 40,000 change -
+    // the confirmed 500,000 is still spent regardless, but since not every
+    // input is trusted, none of tx2's own change counts yet.
+    test('should not credit change from a tx that mixes a confirmed input with an untrusted one, even though the confirmed spend still counts', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '500000',
         unconfirmedBalance: '460000',
@@ -170,13 +171,14 @@ describe('BlockbookClient', () => {
 
       const balance = await client.getBalance(ADDRESS)
 
-      expect(balance.unconfirmedOutgoing).toBe(460000)
+      expect(balance.unconfirmedOutgoing).toBe(500000)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
     })
 
     // tx1: spends confirmed 1,000,000, sends 300,000, keeps 700,000 change.
     // tx3: spends that same 700,000, sends 400,000, keeps 300,000 - tx3's
     // further spend must reduce the balance too, not just tx1's own portion.
-    test('should subtract a further pending spend of a rooted change output instead of double-crediting it', async () => {
+    test('should subtract a further pending spend of a trusted change output instead of double-crediting it', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '1000000',
         unconfirmedBalance: '-700000',
@@ -211,7 +213,7 @@ describe('BlockbookClient', () => {
     // tx1: spends confirmed 300,000, keeps 200,000 change. tx4: spends a
     // separate confirmed 500,000 AND tx1's 200,000 change together, keeps
     // 150,000 - both inputs are real, so both should count.
-    test('should count both a direct confirmed input and a chained input from another rooted transaction', async () => {
+    test('should count both a direct confirmed input and a chained input from another trusted transaction', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '800000',
         unconfirmedBalance: '-650000',
@@ -246,7 +248,7 @@ describe('BlockbookClient', () => {
       expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(150000)
     })
 
-    // t1: unconfirmed deposit, not rooted. t2 spends t1's output, t3 spends
+    // t1: unconfirmed deposit, not trusted. t2 spends t1's output, t3 spends
     // t2's output - the whole 3-hop chain never touches confirmed money, so
     // it must net to zero however many hops deep it goes.
     test('should ignore a multi-hop chain of pending transactions that never touches confirmed money', async () => {
@@ -285,6 +287,88 @@ describe('BlockbookClient', () => {
 
       expect(balance.unconfirmedOutgoing).toBe(0)
       expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
+    })
+
+    // A tx spends a confirmed 5,000 alongside an unconfirmed deposit from
+    // elsewhere (10,000), keeping 9,000 change. Since not every input is
+    // trusted, none of this tx's own change counts yet - only the confirmed
+    // 5,000 it spent is reflected, dropping the balance to 0 until the whole
+    // thing (including the deposit) actually confirms.
+    test('should not credit any change from a tx that mixes confirmed money with an untrusted deposit', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '5000',
+        unconfirmedBalance: '4000',
+        transactions: [
+          {
+            txid: 'dep',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '10000', txid: 'prev-dep' }],
+            vout: [{ isAddress: true, addresses: [ADDRESS], value: '10000', n: 0 }]
+          },
+          {
+            txid: 'mixed',
+            blockHeight: -1,
+            vin: [
+              { isAddress: true, addresses: [ADDRESS], value: '5000', txid: 'confirmed-A' },
+              { isAddress: true, addresses: [ADDRESS], value: '10000', txid: 'dep', vout: 0 }
+            ],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '9000', n: 0 },
+              { isAddress: true, addresses: ['ext'], value: '6000', n: 1 }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(5000)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
+    })
+
+    // Same mixed tx as above, but alongside a second, unrelated fully-trusted
+    // send (confirmed 100,000 -> 80,000 out, 20,000 change). Each transaction
+    // must be counted independently - the untrusted mixed tx still only loses
+    // its confirmed 5,000, while the separate trusted send is counted in full.
+    test('should count a partially-untrusted tx and a separate fully-trusted tx independently', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '105000',
+        unconfirmedBalance: '84000',
+        transactions: [
+          {
+            txid: 'dep',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: ['someone-else'], value: '10000', txid: 'prev-dep' }],
+            vout: [{ isAddress: true, addresses: [ADDRESS], value: '10000', n: 0 }]
+          },
+          {
+            txid: 'mixed',
+            blockHeight: -1,
+            vin: [
+              { isAddress: true, addresses: [ADDRESS], value: '5000', txid: 'confirmed-A' },
+              { isAddress: true, addresses: [ADDRESS], value: '10000', txid: 'dep', vout: 0 }
+            ],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '9000', n: 0 },
+              { isAddress: true, addresses: ['ext'], value: '6000', n: 1 }
+            ]
+          },
+          {
+            txid: 'other',
+            blockHeight: -1,
+            vin: [{ isAddress: true, addresses: [ADDRESS], value: '100000', txid: 'confirmed-B' }],
+            vout: [
+              { isAddress: true, addresses: [ADDRESS], value: '20000', n: 0 },
+              { isAddress: true, addresses: ['ext2'], value: '80000', n: 1 }
+            ]
+          }
+        ]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(85000)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(20000)
     })
 
     test('should ignore confirmed transactions when computing the outgoing amount', async () => {

--- a/tests/blockbook-client.test.js
+++ b/tests/blockbook-client.test.js
@@ -371,6 +371,35 @@ describe('BlockbookClient', () => {
       expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(20000)
     })
 
+    // A tx spends a confirmed 500,000 of ours AND an unrelated third party's
+    // 200,000 input together, keeping 300,000 change. Even though our own
+    // input is directly confirmed, the tx as a whole isn't trusted (it has an
+    // input that was never ours at all) - so the confirmed 500,000 still
+    // counts as spent, but none of the change is credited yet.
+    test('should not trust a tx that mixes our confirmed input with an unrelated third party\'s input', async () => {
+      fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
+        balance: '500000',
+        unconfirmedBalance: '200000',
+        transactions: [{
+          txid: 'shared',
+          blockHeight: -1,
+          vin: [
+            { isAddress: true, addresses: [ADDRESS], value: '500000', txid: 'confirmed-A' },
+            { isAddress: true, addresses: ['someone-else'], value: '200000', txid: 'foreign-prev' }
+          ],
+          vout: [
+            { isAddress: true, addresses: [ADDRESS], value: '300000', n: 0 },
+            { isAddress: true, addresses: ['someone-else'], value: '400000', n: 1 }
+          ]
+        }]
+      }))
+
+      const balance = await client.getBalance(ADDRESS)
+
+      expect(balance.unconfirmedOutgoing).toBe(500000)
+      expect(balance.confirmed - balance.unconfirmedOutgoing).toBe(0)
+    })
+
     test('should ignore confirmed transactions when computing the outgoing amount', async () => {
       fetchMock.mockResolvedValueOnce(mockBlockbookAddress({
         balance: '100000',

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -210,3 +210,30 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
     })
   })
 })
+
+describe('WalletAccountReadOnlyBtc getBalance formula', () => {
+  function stubClient (balance) {
+    return {
+      connect: async () => {},
+      getBalance: async () => balance
+    }
+  }
+
+  test('should subtract unconfirmedOutgoing when the client reports it', async () => {
+    const account = new WalletAccountReadOnlyBtc(ADDRESSES[84], { network: 'regtest' })
+    account._client = stubClient({ confirmed: 100_000, unconfirmed: 999_999, unconfirmedOutgoing: 30_000 })
+
+    const balance = await account.getBalance()
+
+    expect(balance).toBe(70_000n)
+  })
+
+  test('should fall back to netting the raw unconfirmed balance when the client does not report unconfirmedOutgoing', async () => {
+    const account = new WalletAccountReadOnlyBtc(ADDRESSES[84], { network: 'regtest' })
+    account._client = stubClient({ confirmed: 100_000, unconfirmed: -30_000 })
+
+    const balance = await account.getBalance()
+
+    expect(balance).toBe(70_000n)
+  })
+})

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -220,8 +220,10 @@ describe('WalletAccountReadOnlyBtc getBalance formula', () => {
   }
 
   test('should subtract unconfirmedOutgoing when the client reports it', async () => {
-    const account = new WalletAccountReadOnlyBtc(ADDRESSES[84], { network: 'regtest' })
-    account._client = stubClient({ confirmed: 100_000, unconfirmed: 999_999, unconfirmedOutgoing: 30_000 })
+    const account = new WalletAccountReadOnlyBtc(ADDRESSES[84], {
+      network: 'regtest',
+      client: stubClient({ confirmed: 100_000, unconfirmed: 999_999, unconfirmedOutgoing: 30_000 })
+    })
 
     const balance = await account.getBalance()
 
@@ -229,8 +231,10 @@ describe('WalletAccountReadOnlyBtc getBalance formula', () => {
   })
 
   test('should fall back to netting the raw unconfirmed balance when the client does not report unconfirmedOutgoing', async () => {
-    const account = new WalletAccountReadOnlyBtc(ADDRESSES[84], { network: 'regtest' })
-    account._client = stubClient({ confirmed: 100_000, unconfirmed: -30_000 })
+    const account = new WalletAccountReadOnlyBtc(ADDRESSES[84], {
+      network: 'regtest',
+      client: stubClient({ confirmed: 100_000, unconfirmed: -30_000 })
+    })
 
     const balance = await account.getBalance()
 

--- a/types/src/transports/blockbook-client.d.ts
+++ b/types/src/transports/blockbook-client.d.ts
@@ -1,12 +1,4 @@
 /**
- * @typedef {Object} BlockbookClientConfig
- * @property {string} url - The Blockbook server base URL (e.g., 'https://btc1.trezor.io/api').
- */
-/** @typedef {import('./btc-client.js').default} IBtcClient */
-/** @typedef {import('./btc-client.js').BtcBalance} BtcBalance */
-/** @typedef {import('./btc-client.js').BtcUtxo} BtcUtxo */
-/** @typedef {import('./btc-client.js').BtcHistoryItem} BtcHistoryItem */
-/**
  * Stateless BTC client backed by the Blockbook v2 REST API.
  *
  * @implements {IBtcClient}
@@ -22,7 +14,7 @@ export default class BlockbookClient implements IBtcClient {
      * @private
      * @type {string}
      */
-    private _baseUrl;
+    private _baseUrl: string;
     /**
      * Establishes the connection to the server.
      * Blockbook is a stateless REST API, so clients don't need to call this method.
@@ -90,20 +82,29 @@ export default class BlockbookClient implements IBtcClient {
      * @throws {Error} If fee estimation is unavailable from both sources.
      */
     estimateFee(blocks: number): Promise<number>;
-    /** @private */
+    /**
+     * @private
+     * @param {number} blocks
+     * @returns {Promise<number | null>} Fee rate in BTC/kB, or null if unavailable.
+     */
     private _estimateFeeFromBlockbook;
-    /** @private */
+    /**
+     * @private
+     * @param {number} blocks
+     * @returns {Promise<number>} Fee rate in BTC/kB.
+     * @throws {Error} If fee estimation is unavailable.
+     */
     private _estimateFeeFromMempool;
     /** @private */
     private _get;
 }
-export type BlockbookClientConfig = {
-    /**
-     * - The Blockbook server base URL (e.g., 'https://btc1.trezor.io/api').
-     */
-    url: string;
-};
 export type IBtcClient = import("./btc-client.js").default;
 export type BtcBalance = import("./btc-client.js").BtcBalance;
 export type BtcUtxo = import("./btc-client.js").BtcUtxo;
 export type BtcHistoryItem = import("./btc-client.js").BtcHistoryItem;
+export type BlockbookClientConfig = {
+    /**
+     * - The Blockbook server API base URL (e.g., 'https://btc1.trezor.io/api').
+     */
+    url: string;
+};

--- a/types/src/transports/btc-client.d.ts
+++ b/types/src/transports/btc-client.d.ts
@@ -1,24 +1,3 @@
-/**
- * @typedef {Object} BtcClientConfig
- * @property {number} [timeout] - Connection timeout in milliseconds (default: 15_000).
- */
-/**
- * @typedef {Object} BtcBalance
- * @property {number} confirmed - Confirmed balance in satoshis.
- * @property {number} [unconfirmed] - Unconfirmed balance in satoshis.
- */
-/**
- * @typedef {Object} BtcUtxo
- * @property {string} tx_hash - The transaction hash containing this UTXO.
- * @property {number} tx_pos - The output index within the transaction.
- * @property {number} value - The UTXO value in satoshis.
- * @property {number} [height] - The block height (0 if unconfirmed).
- */
-/**
- * @typedef {Object} BtcHistoryItem
- * @property {string} tx_hash - The transaction hash.
- * @property {number} height - The block height (0 or negative if unconfirmed).
- */
 /** @interface */
 export default interface IBtcClient {
     /**

--- a/types/src/transports/btc-client.d.ts
+++ b/types/src/transports/btc-client.d.ts
@@ -108,6 +108,10 @@ export type BtcBalance = {
      * - Unconfirmed balance in satoshis.
      */
     unconfirmed?: number;
+    /**
+     * - Amount leaving the address through unconfirmed transactions, in satoshis.
+     */
+    unconfirmedOutgoing?: number;
 };
 export type BtcUtxo = {
     /**

--- a/types/src/transports/btc-client.d.ts
+++ b/types/src/transports/btc-client.d.ts
@@ -89,6 +89,8 @@ export type BtcBalance = {
     unconfirmed?: number;
     /**
      * - Amount leaving the address through unconfirmed transactions, in satoshis.
+     * Clients that implement this should follow the same trust rule as {@link BlockbookClient}'s `getUnconfirmedOutgoing`,
+     * so `getBalance()` behaves consistently regardless of which client backs it.
      */
     unconfirmedOutgoing?: number;
 };

--- a/types/src/transports/index.d.ts
+++ b/types/src/transports/index.d.ts
@@ -9,5 +9,4 @@ export type BtcClientConfig = import("./btc-client.js").BtcClientConfig;
 export type BtcBalance = import("./btc-client.js").BtcBalance;
 export type BtcUtxo = import("./btc-client.js").BtcUtxo;
 export type BtcHistoryItem = import("./btc-client.js").BtcHistoryItem;
-export type BlockbookClientConfig = import("./blockbook-client.js").BlockbookClientConfig;
 export type MempoolElectrumConfig = import("./mempool-electrum-client.js").MempoolElectrumConfig;

--- a/types/src/transports/mempool-electrum-client.d.ts
+++ b/types/src/transports/mempool-electrum-client.d.ts
@@ -1,18 +1,4 @@
 /**
- * @typedef {Object} MempoolElectrumConfig
- * @property {string} host - The Electrum server hostname.
- * @property {number} port - The Electrum server port.
- * @property {'tcp' | 'ssl' | 'tls'} [protocol] - The transport protocol (default: 'tcp').
- * @property {number} [maxRetry] - Maximum reconnection attempts (default: 2).
- * @property {number} [retryPeriod] - Delay between reconnection attempts in milliseconds (default: 1000).
- * @property {number} [pingPeriod] - Delay between keep-alive pings in milliseconds (default: 120000).
- * @property {(err: Error | null) => void} [callback] - Called when all retries are exhausted.
- */
-/** @typedef {import('./btc-client.js').default} IBtcClient */
-/** @typedef {import('./btc-client.js').BtcBalance} BtcBalance */
-/** @typedef {import('./btc-client.js').BtcUtxo} BtcUtxo */
-/** @typedef {import('./btc-client.js').BtcHistoryItem} BtcHistoryItem */
-/**
  * Electrum client using @mempool/electrum-client.
  *
  * @implements {IBtcClient}
@@ -24,10 +10,7 @@ export default class MempoolElectrumClient implements IBtcClient {
      * @param {MempoolElectrumConfig} config - Configuration options.
      */
     constructor(config: MempoolElectrumConfig);
-    /**
-     * @private
-     * @type {import('bitcoinjs-lib').Network}
-     */
+    /** @private */
     private _network;
     /**
      * @private
@@ -132,6 +115,10 @@ export type MempoolElectrumConfig = {
      * - The transport protocol (default: 'tcp').
      */
     protocol?: "tcp" | "ssl" | "tls";
+    /**
+     * - The network name (default: 'bitcoin').
+     */
+    network?: "bitcoin" | "regtest" | "testnet";
     /**
      * - Maximum reconnection attempts (default: 2).
      */

--- a/types/src/transports/ws.d.ts
+++ b/types/src/transports/ws.d.ts
@@ -1,12 +1,4 @@
 /**
- * @typedef {Object} ElectrumWsConfig
- * @property {string} url - The WebSocket URL (e.g., 'wss://electrum.example.com:50004').
- */
-/** @typedef {import('./btc-client.js').default} IBtcClient */
-/** @typedef {import('./btc-client.js').BtcBalance} BtcBalance */
-/** @typedef {import('./btc-client.js').BtcUtxo} BtcUtxo */
-/** @typedef {import('./btc-client.js').BtcHistoryItem} BtcHistoryItem */
-/**
  * Electrum client using WebSocket transport.
  *
  * Compatible with browser environments where TCP sockets are not available.
@@ -21,10 +13,7 @@ export default class ElectrumWs implements IBtcClient {
      * @param {ElectrumWsConfig} config - Configuration options.
      */
     constructor(config: ElectrumWsConfig);
-    /**
-     * @private
-     * @type {import('bitcoinjs-lib').Network}
-     */
+    /** @private */
     private _network;
     /**
      * @private
@@ -132,6 +121,10 @@ export type ElectrumWsConfig = {
      * - The WebSocket URL (e.g., 'wss://electrum.example.com:50004').
      */
     url: string;
+    /**
+     * - The network name (default: 'bitcoin').
+     */
+    network?: "bitcoin" | "regtest" | "testnet";
 };
 export type IBtcClient = import("./btc-client.js").default;
 export type BtcBalance = import("./btc-client.js").BtcBalance;

--- a/types/src/wallet-account-btc.d.ts
+++ b/types/src/wallet-account-btc.d.ts
@@ -30,7 +30,7 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc implement
     get path(): string;
     /**
      * The account's key pair.
-     * 
+     *
      * The uint8 arrays are bound to the wallet account, so any external change will reflect to the internal representation. For this reason,
      * it's strongly recommended to treat the key pair as a read-only view of the keys. While it's still technically possible to alter their
      * content, client code should never do so.
@@ -89,12 +89,11 @@ export default class WalletAccountBtc extends WalletAccountReadOnlyBtc implement
      * @returns {Promise<WalletAccountReadOnlyBtc>} The read-only account.
      */
     toReadOnlyAccount(): Promise<WalletAccountReadOnlyBtc>;
-    /**
-     * Disposes the wallet account, erasing the private key from memory and closing the connection with the server.
-     */
-    dispose(): void;
+    _btcReadOnlyAccount: WalletAccountReadOnlyBtc;
     /** @private */
     private _getRawTransaction;
+    /** @private */
+    private _buildSignedTransaction;
 }
 export type IWalletAccount = import("@tetherto/wdk-wallet").IWalletAccount;
 export type KeyPair = import("@tetherto/wdk-wallet").KeyPair;

--- a/types/src/wallet-account-read-only-btc.d.ts
+++ b/types/src/wallet-account-read-only-btc.d.ts
@@ -47,7 +47,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
      * @private
      * @type {bigint}
      */
-    private _dustLimit;
+    private _dustLimit: bigint;
     /**
      * Returns the account's bitcoin balance.
      *
@@ -83,21 +83,25 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
      */
     getTransactionReceipt(hash: string): Promise<BtcTransactionReceipt | null>;
     /**
-     * Returns the maximum spendable amount (in satoshis) that can be sent in
+     * Returns an estimation of the maximum spendable amount (in satoshis) that can be sent in
      * a single transaction, after subtracting estimated transaction fees.
      *
-     * The maximum spendable amount can differ from the wallet's total balance.
+     * The estimated maximum spendable amount can differ from the wallet's total balance.
      * A transaction can only include up to MAX_UTXO_INPUTS (default: 200) unspents.
      * Wallets holding more than this limit cannot spend their full balance in a
-     * single transaction.
+     * single transaction. There will likely be some satoshis left over as change.
      *
      * @param {Object} [opts] - Options.
      * @param {number | bigint} [opts.feeRate] - Fee rate in sat/vB. If omitted, estimated via the client.
-     * @returns {Promise<BtcMaxSpendableResult>} The maximum spendable result.
+     * @returns {Promise<BtcMaxSpendableResult>} The estimated maximum spendable result.
      */
     getMaxSpendable(opts?: {
         feeRate?: number | bigint;
     }): Promise<BtcMaxSpendableResult>;
+    /**
+     * Closes any internal connection with the server.
+     */
+    dispose(): void;
     /**
      * Ensures the client is connected.
      *
@@ -156,6 +160,8 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 export type MempoolElectrumConfig = import("./transports/index.js").MempoolElectrumConfig;
 export type MempoolElectrumClient = import("./transports/index.js").MempoolElectrumClient;
 export type IBtcClient = import("./transports/index.js").IBtcClient;
+export type BlockbookClientConfig = import("./transports/blockbook-client.js").BlockbookClientConfig;
+export type ElectrumWsConfig = import("./transports/ws.js").ElectrumWsConfig;
 export type OutputWithValue = import("@bitcoinerlab/coinselect").OutputWithValue;
 export type Network = import("bitcoinjs-lib").Network;
 export type BtcTransactionReceipt = import("bitcoinjs-lib").Transaction;
@@ -180,13 +186,40 @@ export type BtcTransaction = {
      */
     feeRate?: number | bigint;
 };
-export type BtcClientDescriptor =
-    | { type: 'blockbook-http', clientConfig: import("./transports/blockbook-client.js").BlockbookClientConfig }
-    | { type: 'electrum-ws', clientConfig: import("./transports/ws.js").ElectrumWsConfig }
-    | { type: 'electrum', clientConfig: MempoolElectrumConfig };
+export type BtcClientDescriptor = BtcBlockbookHttpClientDescriptor | BtcElectrumClientDescriptor | BtcElectrumWsClientDescriptor;
+export type BtcBlockbookHttpClientDescriptor = {
+    /**
+     * - The client's type.
+     */
+    type: "blockbook-http";
+    /**
+     * - The client's configuration.
+     */
+    clientConfig: BlockbookClientConfig;
+};
+export type BtcElectrumWsClientDescriptor = {
+    /**
+     * - Use a WebSocket Electrum client.
+     */
+    type: "electrum-ws";
+    /**
+     * - The WebSocket client configuration.
+     */
+    clientConfig: Omit<ElectrumWsConfig, "network">;
+};
+export type BtcElectrumClientDescriptor = {
+    /**
+     * - Use a TCP/TLS/SSL Electrum client.
+     */
+    type: "electrum";
+    /**
+     * - The Electrum client configuration.
+     */
+    clientConfig: Omit<MempoolElectrumConfig, "network">;
+};
 export type BtcWalletConfig = {
     /**
-     * - The bitcoin client: a pre-built IBtcClient, a descriptor { type, config }, or an array for failover.
+     * - The bitcoin client, or a list of bitcoin client options for connection fallback.
      */
     client?: IBtcClient | BtcClientDescriptor | Array<IBtcClient | BtcClientDescriptor>;
     /**
@@ -195,9 +228,9 @@ export type BtcWalletConfig = {
     network?: "bitcoin" | "regtest" | "testnet";
     /**
      * - The BIP address type used for key and address derivation.
-     *   - 44: [BIP-44 (P2PKH / legacy)](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
-     *   - 84: [BIP-84 (P2WPKH / native SegWit)](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)
-     *   - Default: 84 (P2WPKH).
+     * - 44: [BIP-44 (P2PKH / legacy)](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)
+     * - 84: [BIP-84 (P2WPKH / native SegWit)](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki)
+     * - Default: 84 (P2WPKH).
      */
     bip?: 44 | 84;
     /**

--- a/types/src/wallet-manager-btc.d.ts
+++ b/types/src/wallet-manager-btc.d.ts
@@ -21,13 +21,6 @@ export default class WalletManagerBtc extends WalletManager {
      */
     protected _client: IBtcClient;
     /**
-     * A list that maps each client to a flag that is true only if the client was externally provided.
-     *
-     * @protected
-     * @type {Array<boolean>}
-     */
-    get _isExternalClient(): Array<boolean>;
-    /**
      * Returns the wallet account at a specific index (defaults to [BIP-84](https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki); set config.bip=44 for [BIP-44](https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki)).
      *
      * @example
@@ -52,15 +45,12 @@ export default class WalletManagerBtc extends WalletManager {
      */
     getAccountByPath(path: string): Promise<WalletAccountBtc>;
     /**
-     * Returns the current fee rates.
+     * A list that maps each client to a flag that is true only if the client was externally provided.
      *
-     * @returns {Promise<FeeRates>} The fee rates (in satoshis).
+     * @protected
+     * @type {Array<boolean>}
      */
-    getFeeRates(): Promise<FeeRates>;
-    /**
-     * Disposes all the wallet accounts, erasing their private keys from the memory and closing all internal connections.
-     */
-    dispose(): void;
+    protected get _isExternalClient(): Array<boolean>;
 }
 export type FeeRates = import("@tetherto/wdk-wallet").FeeRates;
 export type BtcWalletConfig = import("./wallet-account-btc.js").BtcWalletConfig;


### PR DESCRIPTION
# Description
`getBalance` only returns a number which is not very precise to how Bitcoin works. In order to stay as accurate as possible with only 1 number, we should return balance as confirmed balance - unconfirmed outgoing. With this formula, users can see the balance change immediately when they send fund and only see incoming balance change when it's confirmed.

- Changed the logic
- Added tests
- Updated typedefs

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215812858094239