### PR TITLE
Release: v1.0.0-beta.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tetherto/wdk-wallet-btc",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tetherto/wdk-wallet-btc",
-      "version": "1.0.0-beta.12",
+      "version": "1.0.0-beta.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@bitcoinerlab/btcmessage": "4.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tetherto/wdk-wallet-btc",
-  "version": "1.0.0-beta.12",
+  "version": "1.0.0-beta.13",
   "description": "A simple package to manage BIP-32 wallets for the bitcoin blockchain.",
   "keywords": [
     "wdk",


### PR DESCRIPTION
- Bump version to 1.0.0-beta.13

### Changes since v1.0.0-beta.12
- Update balance calculation: confirmed minus unconfirmed outgoing (#99)
- Apply Bitcoin Core wallet policy to unconfirmedOutgoing balance
- Reject transactions with non-owned outputs; add Blockbook tests

### Dependency updates
- None (version bump only; lockfile synced)