### PR TITLE
Add getTransaction method

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,8 +354,6 @@ new WalletAccountBtc(seed, path, config)
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransfers(options?)` | Returns the account's transfer history | `Promise<BtcTransfer[]>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransaction \| null>` |
-| `getTransaction(hash)` | Returns a normalized, finality-based transaction receipt | `Promise<BtcTransactionInfo>` |
-| `waitForTransaction(hash, options?)` | Polls until the transaction reaches the target finality (or times out) | `Promise<BtcTransactionInfo>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<{amount: bigint, fee: bigint, changeValue: bigint}>` |
 | `sign(message)` | Signs a message with the account's private key | `Promise<string>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
@@ -463,41 +461,6 @@ if (receipt) {
 }
 ```
 
-##### `getTransaction(hash)`
-Returns a normalized, finality-based receipt that maps Bitcoin's native state onto a common cross-chain shape (`finality`, `success`, `block`, `fee`, plus the raw transaction).
-
-**Parameters:**
-- `hash` (string): The transaction hash (64 hex characters)
-
-**Returns:** `Promise<BtcTransactionInfo>` - The normalized receipt
-
-**Throws:** `NoSuchElementError` if no transaction is found for the given hash.
-
-**Example:**
-```javascript
-const receipt = await account.getTransaction('abc123...')
-console.log(receipt.finality, receipt.block)
-```
-
-##### `waitForTransaction(hash, options?)`
-Polls `getTransaction` until the transaction reaches the requested finality target, then returns the terminal receipt. Only throws on timeout — callers inspect `finality`/`success` on the returned receipt rather than catching errors for failed or dropped transactions.
-
-**Parameters:**
-- `hash` (string): The transaction hash (64 hex characters)
-- `options` (object, optional):
-  - `target` (string, optional): `'confirmed'` or `'final'` (default: `'confirmed'`)
-  - `timeout` (number, optional): Total time budget in ms (default: `3600000`)
-  - `interval` (number, optional): Poll cadence in ms (default: `30000`)
-
-**Returns:** `Promise<BtcTransactionInfo>` - The terminal receipt once the target is reached
-
-**Throws:** `TimeoutError` if the target is not reached before the timeout.
-
-**Example:**
-```javascript
-const receipt = await account.waitForTransaction('abc123...', { target: 'final' })
-```
-
 ##### `getMaxSpendable()`
 Returns the maximum spendable amount that can be sent in a single transaction. The maximum spendable amount can differ from the wallet's total balance for several reasons:
 - **Transaction fees**: Fees are subtracted from the total balance
@@ -601,8 +564,6 @@ new WalletAccountReadOnlyBtc(address, config)
 | `getBalance()` | Returns the confirmed account balance in satoshis | `Promise<bigint>` |
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransaction \| null>` |
-| `getTransaction(hash)` | Returns a normalized, finality-based transaction receipt | `Promise<BtcTransactionInfo>` |
-| `waitForTransaction(hash, options?)` | Polls until the transaction reaches the target finality (or times out) | `Promise<BtcTransactionInfo>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<{amount: bigint, fee: bigint, changeValue: bigint}>` |
 
 ## 🌐 Supported Networks

--- a/README.md
+++ b/README.md
@@ -354,6 +354,8 @@ new WalletAccountBtc(seed, path, config)
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransfers(options?)` | Returns the account's transfer history | `Promise<BtcTransfer[]>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransaction \| null>` |
+| `getTransaction(hash)` | Returns a normalized, finality-based transaction receipt | `Promise<BtcTransactionInfo>` |
+| `waitForTransaction(hash, options?)` | Polls until the transaction reaches the target finality (or times out) | `Promise<BtcTransactionInfo>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<{amount: bigint, fee: bigint, changeValue: bigint}>` |
 | `sign(message)` | Signs a message with the account's private key | `Promise<string>` |
 | `verify(message, signature)` | Verifies a message signature | `Promise<boolean>` |
@@ -461,6 +463,41 @@ if (receipt) {
 }
 ```
 
+##### `getTransaction(hash)`
+Returns a normalized, finality-based receipt that maps Bitcoin's native state onto a common cross-chain shape (`finality`, `success`, `block`, `fee`, plus the raw transaction).
+
+**Parameters:**
+- `hash` (string): The transaction hash (64 hex characters)
+
+**Returns:** `Promise<BtcTransactionInfo>` - The normalized receipt
+
+**Throws:** `NoSuchElementError` if no transaction is found for the given hash.
+
+**Example:**
+```javascript
+const receipt = await account.getTransaction('abc123...')
+console.log(receipt.finality, receipt.block)
+```
+
+##### `waitForTransaction(hash, options?)`
+Polls `getTransaction` until the transaction reaches the requested finality target, then returns the terminal receipt. Only throws on timeout — callers inspect `finality`/`success` on the returned receipt rather than catching errors for failed or dropped transactions.
+
+**Parameters:**
+- `hash` (string): The transaction hash (64 hex characters)
+- `options` (object, optional):
+  - `target` (string, optional): `'confirmed'` or `'final'` (default: `'confirmed'`)
+  - `timeout` (number, optional): Total time budget in ms (default: `3600000`)
+  - `interval` (number, optional): Poll cadence in ms (default: `30000`)
+
+**Returns:** `Promise<BtcTransactionInfo>` - The terminal receipt once the target is reached
+
+**Throws:** `TimeoutError` if the target is not reached before the timeout.
+
+**Example:**
+```javascript
+const receipt = await account.waitForTransaction('abc123...', { target: 'final' })
+```
+
 ##### `getMaxSpendable()`
 Returns the maximum spendable amount that can be sent in a single transaction. The maximum spendable amount can differ from the wallet's total balance for several reasons:
 - **Transaction fees**: Fees are subtracted from the total balance
@@ -564,6 +601,8 @@ new WalletAccountReadOnlyBtc(address, config)
 | `getBalance()` | Returns the confirmed account balance in satoshis | `Promise<bigint>` |
 | `quoteSendTransaction(options)` | Estimates the fee for a transaction | `Promise<{fee: bigint}>` |
 | `getTransactionReceipt(hash)` | Returns a transaction's receipt | `Promise<BtcTransaction \| null>` |
+| `getTransaction(hash)` | Returns a normalized, finality-based transaction receipt | `Promise<BtcTransactionInfo>` |
+| `waitForTransaction(hash, options?)` | Polls until the transaction reaches the target finality (or times out) | `Promise<BtcTransactionInfo>` |
 | `getMaxSpendable()` | Returns the maximum spendable amount | `Promise<{amount: bigint, fee: bigint, changeValue: bigint}>` |
 
 ## 🌐 Supported Networks

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@
 /** @typedef {import('@tetherto/wdk-wallet').TransferResult} TransferResult */
 
 /** @typedef {import('./src/wallet-account-read-only-btc.js').BtcTransaction} BtcTransaction */
+/** @typedef {import('./src/wallet-account-read-only-btc.js').BtcTransactionInfo} BtcTransactionInfo */
 /** @typedef {import('./src/wallet-account-read-only-btc.js').BtcWalletConfig} BtcWalletConfig */
 /** @typedef {import('./src/wallet-account-read-only-btc.js').BtcMaxSpendableResult} BtcMaxSpendableResult */
 /** @typedef {import('./src/wallet-account-btc.js').BtcTransfer} BtcTransfer */

--- a/src/transports/blockbook-client.js
+++ b/src/transports/blockbook-client.js
@@ -131,6 +131,16 @@ export default class BlockbookClient {
   }
 
   /**
+   * Returns the height of the current best block.
+   *
+   * @returns {Promise<number>} The current block height.
+   */
+  async getBlockHeight () {
+    const data = await this._get('/v2')
+    return Number(data.blockbook?.bestHeight ?? data.backend?.blocks)
+  }
+
+  /**
    * Returns a raw transaction.
    *
    * @param {string} txHash - The transaction hash.

--- a/src/transports/btc-client.js
+++ b/src/transports/btc-client.js
@@ -102,6 +102,15 @@ export default class IBtcClient {
   }
 
   /**
+   * Returns the height of the current best block.
+   *
+   * @returns {Promise<number>} The current block height.
+   */
+  async getBlockHeight () {
+    throw new NotImplementedError('getBlockHeight()')
+  }
+
+  /**
    * Returns a raw transaction.
    *
    * @param {string} txHash - The transaction hash.

--- a/src/transports/mempool-electrum-client.js
+++ b/src/transports/mempool-electrum-client.js
@@ -169,6 +169,16 @@ export default class MempoolElectrumClient {
   }
 
   /**
+   * Returns the height of the current best block.
+   *
+   * @returns {Promise<number>} The current block height.
+   */
+  async getBlockHeight () {
+    const header = await this._client.blockchainHeaders_subscribe()
+    return header.height
+  }
+
+  /**
    * Returns a raw transaction.
    *
    * @param {string} txHash - The transaction hash.

--- a/src/transports/ws.js
+++ b/src/transports/ws.js
@@ -265,6 +265,16 @@ export default class ElectrumWs {
   }
 
   /**
+   * Returns the height of the current best block.
+   *
+   * @returns {Promise<number>} The current block height.
+   */
+  async getBlockHeight () {
+    const header = await this._request('blockchain.headers.subscribe', [])
+    return header.height
+  }
+
+  /**
    * Returns a raw transaction.
    *
    * @param {string} txHash - The transaction hash.

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -14,7 +14,7 @@
 
 'use strict'
 
-import { WalletAccountReadOnly } from '@tetherto/wdk-wallet'
+import { WalletAccountReadOnly, NoSuchElementError, ValueError } from '@tetherto/wdk-wallet'
 
 import { coinselect } from '@bitcoinerlab/coinselect'
 import { DescriptorsFactory } from '@bitcoinerlab/descriptors'
@@ -282,11 +282,13 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
    * Returns a normalized, finality-based receipt for a transaction.
    *
    * @param {string} hash - The transaction's hash.
-   * @returns {Promise<BtcTransactionInfo | null>} The normalized receipt, or null if the transaction is not known.
+   * @returns {Promise<BtcTransactionInfo>} The normalized receipt.
+   * @throws {ValueError} If the hash is not a valid transaction hash.
+   * @throws {NoSuchElementError} If no transaction has been found for the given hash.
    */
   async getTransaction (hash) {
     if (!/^[0-9a-fA-F]{64}$/.test(hash)) {
-      throw new Error("The 'getTransaction(hash)' method requires a valid transaction hash.")
+      throw new ValueError("The 'getTransaction(hash)' method requires a valid transaction hash.")
     }
 
     await this._ensureConnected()
@@ -296,7 +298,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     const item = Array.isArray(history) ? history.find(h => h?.tx_hash === hash) : null
 
     if (!item) {
-      return null
+      throw new NoSuchElementError(`No transaction found for '${hash}'.`)
     }
 
     const transaction = Transaction.fromHex(await this._client.getTransaction(hash))

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -303,7 +303,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
 
     if (!item.height || item.height <= 0) {
       return {
-        id: hash,
+        hash,
         finality: 'pending',
         confirmations: 0,
         transaction
@@ -313,7 +313,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     const confirmations = await this._getConfirmations(item.height)
 
     return {
-      id: hash,
+      hash,
       finality: confirmations !== null && confirmations >= FINAL_CONFIRMATIONS ? 'final' : 'confirmed',
       success: true,
       block: item.height,

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -305,7 +305,6 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
       return {
         id: hash,
         finality: 'pending',
-        success: null,
         confirmations: 0,
         transaction
       }
@@ -317,7 +316,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
       id: hash,
       finality: confirmations !== null && confirmations >= FINAL_CONFIRMATIONS ? 'final' : 'confirmed',
       success: true,
-      blockRef: item.height,
+      block: item.height,
       confirmations,
       transaction
     }

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -346,14 +346,10 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
   }
 
   /** @protected @type {number} */
-  get _defaultWaitInterval () {
-    return 30000
-  }
+  static _DEFAULT_WAIT_INTERVAL = 30000
 
   /** @protected @type {number} */
-  get _defaultWaitTimeout () {
-    return 3600000
-  }
+  static _DEFAULT_WAIT_TIMEOUT = 3600000
 
   /**
    * Returns an estimation of the maximum spendable amount (in satoshis) that can be sent in

--- a/src/wallet-account-read-only-btc.js
+++ b/src/wallet-account-read-only-btc.js
@@ -44,6 +44,16 @@ const bitcoinMessage = MessageFactory(ecc)
 /** @typedef {import('@tetherto/wdk-wallet').TransactionResult} TransactionResult */
 /** @typedef {import('@tetherto/wdk-wallet').TransferOptions} TransferOptions */
 /** @typedef {import('@tetherto/wdk-wallet').TransferResult} TransferResult */
+/** @typedef {import('@tetherto/wdk-wallet').TransactionReceipt} TransactionReceipt */
+
+/**
+ * A normalized bitcoin transaction receipt, extended with the confirmation depth and the native bitcoinjs transaction.
+ *
+ * @typedef {TransactionReceipt & {
+ *   confirmations: number | null,
+ *   transaction: BtcTransactionReceipt
+ * }} BtcTransactionInfo
+ */
 
 /**
  * @typedef {Object} BtcTransaction
@@ -98,6 +108,7 @@ const { Output } = DescriptorsFactory(ecc)
 
 const MIN_TX_FEE_SATS = 141
 const MAX_UTXO_INPUTS = 200
+const FINAL_CONFIRMATIONS = 6
 
 const BIP_BY_ADDRESS_PREFIX = {
   1: 44,
@@ -241,6 +252,7 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
   /**
    * Returns a transaction's receipt.
    *
+   * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The raw bitcoinjs transaction remains available on its `transaction` property.
    * @param {string} hash - The transaction's hash.
    * @returns {Promise<BtcTransactionReceipt | null>} – The receipt, or null if the transaction has not been included in a block yet.
    */
@@ -264,6 +276,82 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     const transaction = Transaction.fromHex(hex)
 
     return transaction
+  }
+
+  /**
+   * Returns a normalized, finality-based receipt for a transaction.
+   *
+   * @param {string} hash - The transaction's hash.
+   * @returns {Promise<BtcTransactionInfo | null>} The normalized receipt, or null if the transaction is not known.
+   */
+  async getTransaction (hash) {
+    if (!/^[0-9a-fA-F]{64}$/.test(hash)) {
+      throw new Error("The 'getTransaction(hash)' method requires a valid transaction hash.")
+    }
+
+    await this._ensureConnected()
+
+    const address = await this.getAddress()
+    const history = await this._client.getHistory(address)
+    const item = Array.isArray(history) ? history.find(h => h?.tx_hash === hash) : null
+
+    if (!item) {
+      return null
+    }
+
+    const transaction = Transaction.fromHex(await this._client.getTransaction(hash))
+
+    if (!item.height || item.height <= 0) {
+      return {
+        id: hash,
+        finality: 'pending',
+        success: null,
+        confirmations: 0,
+        transaction
+      }
+    }
+
+    const confirmations = await this._getConfirmations(item.height)
+
+    return {
+      id: hash,
+      finality: confirmations !== null && confirmations >= FINAL_CONFIRMATIONS ? 'final' : 'confirmed',
+      success: true,
+      blockRef: item.height,
+      confirmations,
+      transaction
+    }
+  }
+
+  /**
+   * Returns the confirmation depth for a transaction included at the given block height, or null when the chain tip can't be resolved.
+   *
+   * @protected
+   * @param {number} height - The block height the transaction was included in.
+   * @returns {Promise<number | null>} The confirmation depth, or null.
+   */
+  async _getConfirmations (height) {
+    if (typeof this._client.getBlockHeight !== 'function') {
+      return null
+    }
+
+    const tip = await this._client.getBlockHeight()
+
+    if (!tip || tip < height) {
+      return null
+    }
+
+    return tip - height + 1
+  }
+
+  /** @protected @type {number} */
+  get _defaultWaitInterval () {
+    return 30000
+  }
+
+  /** @protected @type {number} */
+  get _defaultWaitTimeout () {
+    return 3600000
   }
 
   /**

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -212,7 +212,7 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
 
       expect(info).not.toBeNull()
       expect(info.finality).toBe('pending')
-      expect(info.success).toBeNull()
+      expect(info.success).toBeUndefined()
       expect(info.confirmations).toBe(0)
       expect(info.transaction).toBeDefined()
     })
@@ -225,7 +225,7 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
       expect(info.finality).toBe('confirmed')
       expect(info.success).toBe(true)
       expect(info.confirmations).toBe(1)
-      expect(typeof info.blockRef).toBe('number')
+      expect(typeof info.block).toBe('number')
       expect(info.transaction).toBeDefined()
     })
 

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -5,6 +5,7 @@ import { HOST, PORT, ELECTRUM_PORT, ZMQ_PORT, DATA_DIR } from './config.js'
 import { BitcoinCli, Waiter } from './helpers/index.js'
 
 import { WalletAccountReadOnlyBtc } from '../index.js'
+import { NoSuchElementError, ValueError } from '@tetherto/wdk-wallet'
 
 const ADDRESSES = {
   // 0'/0/404
@@ -205,8 +206,12 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
       const start = Date.now()
 
       while (Date.now() - start < 15_000) {
-        info = await account.getTransaction(txid)
-        if (info) break
+        try {
+          info = await account.getTransaction(txid)
+          break
+        } catch (err) {
+          if (!(err instanceof NoSuchElementError)) throw err
+        }
         await new Promise(resolve => setTimeout(resolve, 500))
       }
 
@@ -238,15 +243,13 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
       expect(info.confirmations).toBeGreaterThanOrEqual(6)
     })
 
-    test('should return null for an unknown transaction', async () => {
-      const info = await account.getTransaction('f'.repeat(64))
-
-      expect(info).toBeNull()
+    test('should throw NoSuchElementError for an unknown transaction', async () => {
+      await expect(account.getTransaction('f'.repeat(64))).rejects.toThrow(NoSuchElementError)
     })
 
-    test('should throw on a malformed transaction hash', async () => {
+    test('should throw ValueError on a malformed transaction hash', async () => {
       await expect(account.getTransaction('not-a-hash'))
-        .rejects.toThrow("The 'getTransaction(hash)' method requires a valid transaction hash.")
+        .rejects.toThrow(ValueError)
     })
   })
 

--- a/tests/wallet-account-read-only-btc.test.js
+++ b/tests/wallet-account-read-only-btc.test.js
@@ -193,6 +193,63 @@ describe.each([44, 84])('WalletAccountReadOnlyBtc', (bip) => {
     })
   })
 
+  describe('getTransaction', () => {
+    let txid
+
+    beforeAll(() => {
+      txid = bitcoin.sendToAddress(ADDRESSES[bip], 0.005)
+    })
+
+    test('should report pending for an unconfirmed transaction', async () => {
+      let info = null
+      const start = Date.now()
+
+      while (Date.now() - start < 15_000) {
+        info = await account.getTransaction(txid)
+        if (info) break
+        await new Promise(resolve => setTimeout(resolve, 500))
+      }
+
+      expect(info).not.toBeNull()
+      expect(info.finality).toBe('pending')
+      expect(info.success).toBeNull()
+      expect(info.confirmations).toBe(0)
+      expect(info.transaction).toBeDefined()
+    })
+
+    test('should report confirmed after one confirmation', async () => {
+      await waiter.mine(1)
+
+      const info = await account.getTransaction(txid)
+
+      expect(info.finality).toBe('confirmed')
+      expect(info.success).toBe(true)
+      expect(info.confirmations).toBe(1)
+      expect(typeof info.blockRef).toBe('number')
+      expect(info.transaction).toBeDefined()
+    })
+
+    test('should report final after six confirmations', async () => {
+      await waiter.mine(5)
+
+      const info = await account.getTransaction(txid)
+
+      expect(info.finality).toBe('final')
+      expect(info.confirmations).toBeGreaterThanOrEqual(6)
+    })
+
+    test('should return null for an unknown transaction', async () => {
+      const info = await account.getTransaction('f'.repeat(64))
+
+      expect(info).toBeNull()
+    })
+
+    test('should throw on a malformed transaction hash', async () => {
+      await expect(account.getTransaction('not-a-hash'))
+        .rejects.toThrow("The 'getTransaction(hash)' method requires a valid transaction hash.")
+    })
+  })
+
   describe('verify', () => {
     test('should return true for a valid signature', async () => {
         const result = await account.verify(MESSAGE, SIGNATURES[bip])

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@ export type TransactionResult = import("@tetherto/wdk-wallet").TransactionResult
 export type TransferOptions = import("@tetherto/wdk-wallet").TransferOptions;
 export type TransferResult = import("@tetherto/wdk-wallet").TransferResult;
 export type BtcTransaction = import("./src/wallet-account-read-only-btc.js").BtcTransaction;
+export type BtcTransactionInfo = import("./src/wallet-account-read-only-btc.js").BtcTransactionInfo;
 export type BtcWalletConfig = import("./src/wallet-account-read-only-btc.js").BtcWalletConfig;
 export type BtcMaxSpendableResult = import("./src/wallet-account-read-only-btc.js").BtcMaxSpendableResult;
 export type BtcTransfer = import("./src/wallet-account-btc.js").BtcTransfer;

--- a/types/src/transports/blockbook-client.d.ts
+++ b/types/src/transports/blockbook-client.d.ts
@@ -66,6 +66,12 @@ export default class BlockbookClient implements IBtcClient {
      */
     getHistory(address: string): Promise<BtcHistoryItem[]>;
     /**
+     * Returns the height of the current best block.
+     *
+     * @returns {Promise<number>} The current block height.
+     */
+    getBlockHeight(): Promise<number>;
+    /**
      * Returns a raw transaction.
      *
      * @param {string} txHash - The transaction hash.

--- a/types/src/transports/btc-client.d.ts
+++ b/types/src/transports/btc-client.d.ts
@@ -61,6 +61,12 @@ export default interface IBtcClient {
      */
     getHistory(address: string): Promise<BtcHistoryItem[]>;
     /**
+     * Returns the height of the current best block.
+     *
+     * @returns {Promise<number>} The current block height.
+     */
+    getBlockHeight(): Promise<number>;
+    /**
      * Returns a raw transaction.
      *
      * @param {string} txHash - The transaction hash.

--- a/types/src/transports/mempool-electrum-client.d.ts
+++ b/types/src/transports/mempool-electrum-client.d.ts
@@ -94,6 +94,12 @@ export default class MempoolElectrumClient implements IBtcClient {
      */
     getHistory(address: string): Promise<BtcHistoryItem[]>;
     /**
+     * Returns the height of the current best block.
+     *
+     * @returns {Promise<number>} The current block height.
+     */
+    getBlockHeight(): Promise<number>;
+    /**
      * Returns a raw transaction.
      *
      * @param {string} txHash - The transaction hash.

--- a/types/src/transports/ws.d.ts
+++ b/types/src/transports/ws.d.ts
@@ -102,6 +102,12 @@ export default class ElectrumWs implements IBtcClient {
      */
     getHistory(address: string): Promise<BtcHistoryItem[]>;
     /**
+     * Returns the height of the current best block.
+     *
+     * @returns {Promise<number>} The current block height.
+     */
+    getBlockHeight(): Promise<number>;
+    /**
      * Returns a raw transaction.
      *
      * @param {string} txHash - The transaction hash.

--- a/types/src/wallet-account-read-only-btc.d.ts
+++ b/types/src/wallet-account-read-only-btc.d.ts
@@ -87,9 +87,11 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
      * Returns a normalized, finality-based receipt for a transaction.
      *
      * @param {string} hash - The transaction's hash.
-     * @returns {Promise<BtcTransactionInfo | null>} The normalized receipt, or null if the transaction is not known.
+     * @returns {Promise<BtcTransactionInfo>} The normalized receipt.
+     * @throws {ValueError} If the hash is not a valid transaction hash.
+     * @throws {NoSuchElementError} If no transaction has been found for the given hash.
      */
-    getTransaction(hash: string): Promise<BtcTransactionInfo | null>;
+    getTransaction(hash: string): Promise<BtcTransactionInfo>;
     /**
      * Returns the confirmation depth for a transaction included at the given block height, or null when the chain tip can't be resolved.
      *

--- a/types/src/wallet-account-read-only-btc.d.ts
+++ b/types/src/wallet-account-read-only-btc.d.ts
@@ -78,10 +78,30 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
     /**
      * Returns a transaction's receipt.
      *
+     * @deprecated Use {@link getTransaction} instead, which returns a normalized, finality-based receipt. The raw bitcoinjs transaction remains available on its `transaction` property.
      * @param {string} hash - The transaction's hash.
      * @returns {Promise<BtcTransactionReceipt | null>} – The receipt, or null if the transaction has not been included in a block yet.
      */
     getTransactionReceipt(hash: string): Promise<BtcTransactionReceipt | null>;
+    /**
+     * Returns a normalized, finality-based receipt for a transaction.
+     *
+     * @param {string} hash - The transaction's hash.
+     * @returns {Promise<BtcTransactionInfo | null>} The normalized receipt, or null if the transaction is not known.
+     */
+    getTransaction(hash: string): Promise<BtcTransactionInfo | null>;
+    /**
+     * Returns the confirmation depth for a transaction included at the given block height, or null when the chain tip can't be resolved.
+     *
+     * @protected
+     * @param {number} height - The block height the transaction was included in.
+     * @returns {Promise<number | null>} The confirmation depth, or null.
+     */
+    protected _getConfirmations(height: number): Promise<number | null>;
+    /** @protected @type {number} */
+    protected get _defaultWaitInterval(): number;
+    /** @protected @type {number} */
+    protected get _defaultWaitTimeout(): number;
     /**
      * Returns the maximum spendable amount (in satoshis) that can be sent in
      * a single transaction, after subtracting estimated transaction fees.
@@ -162,6 +182,14 @@ export type BtcTransactionReceipt = import("bitcoinjs-lib").Transaction;
 export type TransactionResult = import("@tetherto/wdk-wallet").TransactionResult;
 export type TransferOptions = import("@tetherto/wdk-wallet").TransferOptions;
 export type TransferResult = import("@tetherto/wdk-wallet").TransferResult;
+export type TransactionReceipt = import("@tetherto/wdk-wallet").TransactionReceipt;
+/**
+ * A normalized bitcoin transaction receipt, extended with the confirmation depth and the native bitcoinjs transaction.
+ */
+export type BtcTransactionInfo = TransactionReceipt & {
+    confirmations: number | null;
+    transaction: BtcTransactionReceipt;
+};
 export type BtcTransaction = {
     /**
      * - The transaction's recipient.

--- a/types/src/wallet-account-read-only-btc.d.ts
+++ b/types/src/wallet-account-read-only-btc.d.ts
@@ -101,9 +101,9 @@ export default class WalletAccountReadOnlyBtc extends WalletAccountReadOnly {
      */
     protected _getConfirmations(height: number): Promise<number | null>;
     /** @protected @type {number} */
-    protected get _defaultWaitInterval(): number;
+    protected static _DEFAULT_WAIT_INTERVAL: number;
     /** @protected @type {number} */
-    protected get _defaultWaitTimeout(): number;
+    protected static _DEFAULT_WAIT_TIMEOUT: number;
     /**
      * Returns the maximum spendable amount (in satoshis) that can be sent in
      * a single transaction, after subtracting estimated transaction fees.


### PR DESCRIPTION
# Description
Implements `getTransaction` (and `getTransactionReceipt`) for the <MODULE> wallet
module. It fetches a transaction by its hash and returns a normalized receipt
(status, finality, fee, and chain-specific details) that plugs into the shared
`waitForTransaction` flow.

## Motivation and Context
Consumers need a consistent way to look up a transaction's status and details per
chain. This adds the <CHAIN>-specific implementation behind the shared wallet
interface.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1217123489895950